### PR TITLE
Fixes Authorization for 3.x

### DIFF
--- a/docs/authorize.md
+++ b/docs/authorize.md
@@ -1,0 +1,131 @@
+# TinyAuth Autorization
+
+Enable TinyAuth Authorize if you want to add instant (and easy) role based
+access to your application.
+
+## Enabling
+
+Assuming you already have Authentiction set up correctly you can enable
+Authorization in your controllers beforeFilter like this example:
+
+```php
+// src/Controller/AppController
+
+use Cake\Event\Event;
+
+public function beforeFilter(Event $event)
+{
+	parent::beforeFilter($event);
+	$this->loadComponent('Auth', [
+		'authorize' => [
+			'TinyAuth.Tiny' => [
+				'autoClearCache' => true,
+				'allowUser' => false,
+				'allowAdmin' => false,
+				'adminRole' => 'admin',
+				'superAdminRole' => null
+			]
+		]
+	]);
+}
+```
+
+## Roles
+
+You need to define some roles for Authorize to work, for example:
+
+```php
+// config/app_custom.php
+
+
+/**
+* Optionally define constants for easy referencing throughout your code authorization
+*/
+define('ROLE_PUBLIC', -1);
+define('ROLE_USERS', 1);
+define('ROLE_ADMINS', 2);
+define('ROLE_SUPERADMINS', 9);
+
+return [
+	'Roles' => [
+		'public' => ROLE_PUBLIC,
+		'user' => ROLE_USERS,
+		'admin' => ROLE_ADMINS,
+		'supergirls' => ROLE_SUPERADMINS
+	]
+];
+```
+
+## acl.ini
+
+Authorize expects an ``acl.ini`` file in your config directory.
+Use it to specify who gets access to which resources.
+
+The section key syntax follows the CakePHP naming convention for plugins.
+
+Make sure to create an entry for each action you want to expose and use:
+
+- one or more role names (groups granted access)
+- the ``*`` wildcard to allow access to all authenticated users
+- the special `public` group to allow access to unauthenticated users
+
+```ini
+; ----------------------------------------------------------
+; Userscontroller
+; ----------------------------------------------------------
+[Users]
+index = user, admin, undefined-role
+edit, view = user, admin
+* = admin
+; ----------------------------------------------------------
+; UsersController using /api prefixed route
+; ----------------------------------------------------------
+[api/Users]
+index = public
+view = user
+* = admin
+; ----------------------------------------------------------
+; UsersController using /admin prefixed route
+; ----------------------------------------------------------
+[admin/Users]
+* = admin
+; ----------------------------------------------------------
+; AccountsController in plugin named Accounts
+; ----------------------------------------------------------
+[Accounts.Accounts]
+view, edit = user
+* = admin
+; ----------------------------------------------------------
+; AccountsController in plugin named Accounts using /admin
+; prefixed route
+; ----------------------------------------------------------
+[Accounts.admin/Accounts]
+* = admin
+; ----------------------------------------------------------
+; CompaniesController in plugin named Accounts
+; ----------------------------------------------------------
+[Accounts.Companies]
+view, edit = user
+* = admin
+; ----------------------------------------------------------
+; CompaniesController in plugin named Accounts using /admin
+; prefixed route
+; ----------------------------------------------------------
+[Accounts.admin/Companies]
+* = admin
+```
+
+## Configuration
+
+Authorize supports the following configuration options.
+
+Option  | Type|Description
+--------|------------
+allowUser|boolean|True will give authenticated users access to all resources except those using the `adminPrefix`
+allowAdmin|boolean|True will give users with a role id matching `adminRole` access to all resources using the `adminPrefix`
+adminRole|int|Id of the role you will use as admins. Users with this role are granted access to all actions using `adminPrefix` but only when `allowAdmin` is enabled
+superAdminRole|int|Id of the super admin role. Users with this role will have access to ALL resources.
+adminPrefix|string|Name of the prefix used for admin pages. Defaults to admin.
+autoClearCache|Boolean|True will generate a new acl cache file every time.
+aclKey|string|Name of the column holding your user role id (only for single role per user/BT)
+aclTable|string|Name of the table holding your user roles (only for multiple roles per user/HABTM)

--- a/docs/authorize.md
+++ b/docs/authorize.md
@@ -49,7 +49,7 @@ return [
 	'Roles' => [
 		'user' => ROLE_USERS,
 		'admin' => ROLE_ADMINS,
-		'supergirls' => ROLE_SUPERADMINS
+		'superadmin' => ROLE_SUPERADMIN
 	]
 ];
 ```

--- a/docs/authorize.md
+++ b/docs/authorize.md
@@ -43,7 +43,7 @@ You need to define some roles for Authorize to work, for example:
 */
 define('ROLE_USERS', 1);
 define('ROLE_ADMINS', 2);
-define('ROLE_SUPERADMINS', 9);
+define('ROLE_SUPERADMIN', 9);
 
 return [
 	'Roles' => [

--- a/docs/authorize.md
+++ b/docs/authorize.md
@@ -41,14 +41,12 @@ You need to define some roles for Authorize to work, for example:
 /**
 * Optionally define constants for easy referencing throughout your code
 */
-define('ROLE_PUBLIC', -1);
 define('ROLE_USERS', 1);
 define('ROLE_ADMINS', 2);
 define('ROLE_SUPERADMINS', 9);
 
 return [
 	'Roles' => [
-		'public' => ROLE_PUBLIC,
 		'user' => ROLE_USERS,
 		'admin' => ROLE_ADMINS,
 		'supergirls' => ROLE_SUPERADMINS
@@ -67,7 +65,6 @@ Make sure to create an entry for each action you want to expose and use:
 
 - one or more role names (groups granted access)
 - the ``*`` wildcard to allow access to all authenticated users
-- the special `public` group to allow access to unauthenticated users
 
 ```ini
 ; ----------------------------------------------------------
@@ -81,7 +78,6 @@ edit, view = user, admin
 ; UsersController using /api prefixed route
 ; ----------------------------------------------------------
 [api/Users]
-index = public
 view = user
 * = admin
 ; ----------------------------------------------------------

--- a/docs/authorize.md
+++ b/docs/authorize.md
@@ -39,7 +39,7 @@ You need to define some roles for Authorize to work, for example:
 
 
 /**
-* Optionally define constants for easy referencing throughout your code authorization
+* Optionally define constants for easy referencing throughout your code
 */
 define('ROLE_PUBLIC', -1);
 define('ROLE_USERS', 1);

--- a/src/Auth/TinyAuthorize.php
+++ b/src/Auth/TinyAuthorize.php
@@ -169,8 +169,6 @@ class TinyAuthorize extends BaseAuthorize {
 
 		// allow access if user has been granted access to the specific resource
 		$action = Inflector::underscore($request->action);
-		pr($iniKey);
-
 		if(array_key_exists($action, $this->_acl[$iniKey]['actions']) && !empty($this->_acl[$iniKey]['actions'][$action])) {
 			$matchArray = $this->_acl[$iniKey]['actions'][$action];
 

--- a/src/Auth/TinyAuthorize.php
+++ b/src/Auth/TinyAuthorize.php
@@ -169,6 +169,8 @@ class TinyAuthorize extends BaseAuthorize {
 
 		// allow access if user has been granted access to the specific resource
 		$action = Inflector::underscore($request->action);
+		pr($iniKey);
+
 		if(array_key_exists($action, $this->_acl[$iniKey]['actions']) && !empty($this->_acl[$iniKey]['actions'][$action])) {
 			$matchArray = $this->_acl[$iniKey]['actions'][$action];
 
@@ -287,6 +289,7 @@ class TinyAuthorize extends BaseAuthorize {
 				}
 			}
 		}
+		//pr($res);
 		Cache::write($this->_config['cacheKey'], $res, $this->_config['cache']);
 		return $res;
 	}
@@ -347,12 +350,12 @@ class TinyAuthorize extends BaseAuthorize {
 	 */
 	protected function constructIniKey(Request $request)
 	{
-		$res = $request->params['controller'];
+		$res = Inflector::camelize($request->params['controller']);
 		if (!empty($request->params['prefix'])) {
-			$res = $request->params['prefix'] . "/$res";
+			$res = strtolower($request->params['prefix']) . "/$res";
 		}
 		if (!empty($request->params['plugin'])) {
-			$res = $request->params['plugin'] . ".$res";
+			$res = Inflector::camelize($request->params['plugin']) . ".$res";
 		}
 		return $res;
 	}

--- a/src/Auth/TinyAuthorize.php
+++ b/src/Auth/TinyAuthorize.php
@@ -42,11 +42,11 @@ class TinyAuthorize extends BaseAuthorize {
 	protected $_acl = null;
 
 	protected $_defaultConfig = [
-		'adminRole' => null, // needed together with adminPrefix if allowAdmin is enabled
-		'superAdminRole' => null, // id of the role to grant access to ALL resources
-		'allowUser' => false, // quick way to allow ALL roles access to non prefixed urls
-		'allowAdmin' => false, // quick way to allow admin access to admin prefixed urls
-		'adminPrefix' => 'admin', // must be defined in combination with allowAdmin
+		'adminRole' => null, // id of the admin role used by allowAdmin
+		'superAdminRole' => null, // id of super admin role granted access to ALL resources
+		'allowUser' => false, // enable to allow ALL roles access to all actions except prefixed with 'adminPrefix'
+		'allowAdmin' => false, // enable to allow admin role access to all 'adminPrefix' prefixed urls
+		'adminPrefix' => 'admin', // admin prefix used by  allowAdmin
 		'cache' => AUTH_CACHE,
 		'cacheKey' => 'tiny_auth_acl',
 		'autoClearCache' => false, // usually done by Cache automatically in debug mode,

--- a/src/Auth/TinyAuthorize.php
+++ b/src/Auth/TinyAuthorize.php
@@ -116,8 +116,8 @@ class TinyAuthorize extends BaseAuthorize {
 		$iniKey = $this->_constructIniKey($request);
 		$availableRoles = Configure::read($this->_config['aclTable']);
 
-		// Give any logged in user access to ALL actions if `allowUser` is
-		// enabled, except when the `adminPrefix` is being used.
+		// Give any logged in user access to ALL actions when `allowUser` is
+		// enabled except when the `adminPrefix` is being used.
 		if (!empty($this->_config['allowUser'])) {
 			if (empty($request->params['prefix'])) {
 				return true;
@@ -128,7 +128,7 @@ class TinyAuthorize extends BaseAuthorize {
 		}
 
 		// allow access to all /admin prefixed actions for users belonging to
-		// the specified adminRole.
+		// the specified adminRole id.
 		if (!empty($this->_config['allowAdmin']) && !empty($this->_config['adminRole'])) {
 			if (!empty($request->params['prefix']) && $request->params['prefix'] === $this->_config['adminPrefix']) {
 				if (in_array($this->_config['adminRole'], $roles)) {

--- a/src/Auth/TinyAuthorize.php
+++ b/src/Auth/TinyAuthorize.php
@@ -154,9 +154,6 @@ class TinyAuthorize extends BaseAuthorize {
 		// allow access if user has a role with wildcard access to the resource
 		if (isset($this->_acl[$iniKey]['actions']['*'])) {
 			$matchArray = $this->_acl[$iniKey]['actions']['*'];
-			if (in_array('-1', $matchArray)) {
-				return true;
-			}
 			foreach ($roles as $role) {
 				if (in_array((string)$role, $matchArray)) {
 					return true;
@@ -168,13 +165,6 @@ class TinyAuthorize extends BaseAuthorize {
 		if (isset($this->_acl[$iniKey]['actions'])){
 			if(array_key_exists($request->action, $this->_acl[$iniKey]['actions']) && !empty($this->_acl[$iniKey]['actions'][$request->action])) {
 				$matchArray = $this->_acl[$iniKey]['actions'][$request->action];
-
-				// direct access? (even if he has no roles = GUEST)
-				if (in_array('-1', $matchArray)) {
-					return true;
-				}
-
-				// normal access (rolebased)
 				foreach ($roles as $role) {
 					if (in_array((string)$role, $matchArray)) {
 						return true;

--- a/src/Auth/TinyAuthorize.php
+++ b/src/Auth/TinyAuthorize.php
@@ -116,11 +116,13 @@ class TinyAuthorize extends BaseAuthorize {
 		$iniKey = $this->_constructIniKey($request);
 		$availableRoles = Configure::read($this->_config['aclTable']);
 
-		// allow logged in users access to all actions except prefixed
-		// @todo: this logic is based on the config description above, could
-		// possibly be changed to allow all prefixes as well except /admin
+		// Give any logged in user access to ALL actions if `allowUser` is
+		// enabled, except when the `adminPrefix` is being used.
 		if (!empty($this->_config['allowUser'])) {
 			if (empty($request->params['prefix'])) {
+				return true;
+			}
+			if ($request->params['prefix'] != $this->_config['adminPrefix']) {
 				return true;
 			}
 		}

--- a/src/Auth/TinyAuthorize.php
+++ b/src/Auth/TinyAuthorize.php
@@ -44,9 +44,9 @@ class TinyAuthorize extends BaseAuthorize {
 	protected $_defaultConfig = [
 		'adminRole' => null, // needed together with adminPrefix if allowAdmin is enabled
 		'superAdminRole' => null, // id of the role to grant access to ALL resources
-		'allowUser' => false, // quick way to allow user access to non prefixed urls
+		'allowUser' => false, // quick way to allow ALL roles access to non prefixed urls
 		'allowAdmin' => false, // quick way to allow admin access to admin prefixed urls
-		'adminPrefix' => 'admin',
+		'adminPrefix' => 'admin', // must be defined in combination with allowAdmin
 		'cache' => AUTH_CACHE,
 		'cacheKey' => 'tiny_auth_acl',
 		'autoClearCache' => false, // usually done by Cache automatically in debug mode,
@@ -129,8 +129,7 @@ class TinyAuthorize extends BaseAuthorize {
 		// the specified adminRole.
 		if (!empty($this->_config['allowAdmin']) && !empty($this->_config['adminRole'])) {
 			if (!empty($request->params['prefix']) && $request->params['prefix'] === $this->_config['adminPrefix']) {
-				$adminRoleId = $availableRoles[$this->_config['adminRole']];
-				if (in_array($adminRoleId, $roles)) {
+				if (in_array($this->_config['adminRole'], $roles)) {
 					return true;
 				}
 			}

--- a/src/Auth/TinyAuthorize.php
+++ b/src/Auth/TinyAuthorize.php
@@ -60,8 +60,7 @@ class TinyAuthorize extends BaseAuthorize {
 	 * @param ComponentRegistry $registry
 	 * @param array $config
 	 */
-	public function __construct(ComponentRegistry $registry, array $config = array())
-	{
+	public function __construct(ComponentRegistry $registry, array $config = array()) {
 		$config += $this->_defaultConfig;
 		parent::__construct($registry, $config);
 
@@ -82,8 +81,7 @@ class TinyAuthorize extends BaseAuthorize {
 	 * @param Cake\Network\Request $request The request needing authorization.
 	 * @return bool Success
 	 */
-	public function authorize($user, Request $request)
-	{
+	public function authorize($user, Request $request) {
 		if (isset($user[$this->_config['aclTable']])) {
 			if (isset($user[$this->_config['aclTable']][0]['id'])) {
 				$roles = Hash::extract($user[$this->_config['aclTable']], '{n}.id');
@@ -113,8 +111,7 @@ class TinyAuthorize extends BaseAuthorize {
 	 * @return bool Success
 	 */
 	//public function validate($roles, $plugin, $controller, $action) {
-	public function validate($roles, Request $request)
-	{
+	public function validate($roles, Request $request) {
 		// construct the iniKey and iniMap for easy lookups
 		$iniKey = $this->constructIniKey($request);
 		$availableRoles = Configure::read($this->_config['aclTable']);
@@ -189,8 +186,7 @@ class TinyAuthorize extends BaseAuthorize {
 	/**
 	 * @return Cake\ORM\Table The User table
 	 */
-	public function getTable()
-	{
+	public function getTable() {
 		return TableRegistry::get(CLASS_USER);
 	}
 
@@ -204,8 +200,7 @@ class TinyAuthorize extends BaseAuthorize {
 	 * @param string $path
 	 * @return array Roles
 	 */
-	protected function _getAcl($path = null)
-	{
+	protected function _getAcl($path = null) {
 		if ($path === null) {
 			$path = ROOT . DS . 'config' . DS;
 		}
@@ -300,8 +295,7 @@ class TinyAuthorize extends BaseAuthorize {
 	 * @param string INI section key as found in acl.ini
 	 * @return string String converted to use cake conventions
 	 */
-	protected function normalizeIniKey($key)
-	{
+	protected function normalizeIniKey($key) {
 		$iniMap = $this->deconstructIniKey($key);
 		$res = Inflector::camelize($iniMap['controller']);
 		if (!empty($iniMap['prefix'])) {
@@ -319,8 +313,7 @@ class TinyAuthorize extends BaseAuthorize {
 	 * @param string INI section key as found in acl.ini
 	 * @return array Hash with named keys for controller, plugin and prefix
 	 */
-	protected function deconstructIniKey($key)
-	{
+	protected function deconstructIniKey($key) {
 		$res = [
 			'plugin' => null,
 			'prefix' => null
@@ -344,8 +337,7 @@ class TinyAuthorize extends BaseAuthorize {
 	 * @param Cake\Network\Request $request The request needing authorization.
 	 * @return array Hash with named keys for controller, plugin and prefix
 	 */
-	protected function constructIniKey(Request $request)
-	{
+	protected function constructIniKey(Request $request) {
 		$res = Inflector::camelize($request->params['controller']);
 		if (!empty($request->params['prefix'])) {
 			$res = strtolower($request->params['prefix']) . "/$res";

--- a/src/Auth/TinyAuthorize.php
+++ b/src/Auth/TinyAuthorize.php
@@ -1,14 +1,14 @@
 <?php
 namespace TinyAuth\Auth;
 
-use Cake\Core\Configure;
-use Cake\Cache\Cache;
-use Cake\Utility\Inflector;
-use Cake\Utility\Hash;
 use Cake\Auth\BaseAuthorize;
-use Cake\Network\Request;
+use Cake\Cache\Cache;
 use Cake\Controller\ComponentRegistry;
+use Cake\Core\Configure;
+use Cake\Network\Request;
 use Cake\ORM\TableRegistry;
+use Cake\Utility\Hash;
+use Cake\Utility\Inflector;
 
 if (!defined('CLASS_USER')) {
 	define('CLASS_USER', 'Users'); // override if you have it in a plugin: PluginName.Users etc

--- a/src/Auth/TinyAuthorize.php
+++ b/src/Auth/TinyAuthorize.php
@@ -140,7 +140,7 @@ class TinyAuthorize extends BaseAuthorize {
 		// allow logged in super admins access to all resources
 		if (!empty($this->_config['superAdminRole'])) {
 			foreach ($roles as $role) {
-				if ($role == $this->_config['superAdminRole']) {
+				if ($role === $this->_config['superAdminRole']) {
 					return true;
 				}
 			}
@@ -162,7 +162,7 @@ class TinyAuthorize extends BaseAuthorize {
 		}
 
 		// allow access if user has been granted access to the specific resource
-		if (isset($this->_acl[$iniKey]['actions'])){
+		if (isset($this->_acl[$iniKey]['actions'])) {
 			if(array_key_exists($request->action, $this->_acl[$iniKey]['actions']) && !empty($this->_acl[$iniKey]['actions'][$request->action])) {
 				$matchArray = $this->_acl[$iniKey]['actions'][$request->action];
 				foreach ($roles as $role) {

--- a/src/Auth/TinyAuthorize.php
+++ b/src/Auth/TinyAuthorize.php
@@ -164,9 +164,8 @@ class TinyAuthorize extends BaseAuthorize {
 		}
 
 		// allow access if user has been granted access to the specific resource
-		$action = Inflector::underscore($request->action);
-		if(array_key_exists($action, $this->_acl[$iniKey]['actions']) && !empty($this->_acl[$iniKey]['actions'][$action])) {
-			$matchArray = $this->_acl[$iniKey]['actions'][$action];
+		if(array_key_exists($request->action, $this->_acl[$iniKey]['actions']) && !empty($this->_acl[$iniKey]['actions'][$request->action])) {
+			$matchArray = $this->_acl[$iniKey]['actions'][$request->action];
 
 			// direct access? (even if he has no roles = GUEST)
 			if (in_array('-1', $matchArray)) {
@@ -269,13 +268,12 @@ class TinyAuthorize extends BaseAuthorize {
 					if (!($action = trim($action))) {
 						continue;
 					}
-					$actionName = Inflector::underscore($action);
 					foreach ($roles as $role) {
 						if (!($role = trim($role)) || $role === '*') {
 							continue;
 						}
 						$newRole = Configure::read($this->_config['aclTable'] . '.' . strtolower($role));
-						$res[$key]['actions'][$actionName][] = $newRole;
+						$res[$key]['actions'][$action][] = $newRole;
 
 					}
 				}

--- a/src/Auth/TinyAuthorize.php
+++ b/src/Auth/TinyAuthorize.php
@@ -113,7 +113,7 @@ class TinyAuthorize extends BaseAuthorize {
 	//public function validate($roles, $plugin, $controller, $action) {
 	public function validate($roles, Request $request) {
 		// construct the iniKey and iniMap for easy lookups
-		$iniKey = $this->constructIniKey($request);
+		$iniKey = $this->_constructIniKey($request);
 		$availableRoles = Configure::read($this->_config['aclTable']);
 
 		// allow logged in users access to all actions except prefixed
@@ -240,8 +240,8 @@ class TinyAuthorize extends BaseAuthorize {
 
 		$res = [];
 		foreach ($iniArray as $key => $array) {
-			$key = $this->normalizeIniKey($key);
-			$res[$key] = $this->deconstructIniKey($key);
+			$key = $this->_normalizeIniKey($key);
+			$res[$key] = $this->_deconstructIniKey($key);
 
 			foreach ($array as $actions => $roles) {
 				// get all roles used in the current ini section
@@ -293,8 +293,8 @@ class TinyAuthorize extends BaseAuthorize {
 	 * @param string INI section key as found in acl.ini
 	 * @return string String converted to use cake conventions
 	 */
-	protected function normalizeIniKey($key) {
-		$iniMap = $this->deconstructIniKey($key);
+	protected function _normalizeIniKey($key) {
+		$iniMap = $this->_deconstructIniKey($key);
 		$res = Inflector::camelize($iniMap['controller']);
 		if (!empty($iniMap['prefix'])) {
 			$res = strtolower($iniMap['prefix']) . "/$res";
@@ -311,7 +311,7 @@ class TinyAuthorize extends BaseAuthorize {
 	 * @param string INI section key as found in acl.ini
 	 * @return array Hash with named keys for controller, plugin and prefix
 	 */
-	protected function deconstructIniKey($key) {
+	protected function _deconstructIniKey($key) {
 		$res = [
 			'plugin' => null,
 			'prefix' => null
@@ -335,7 +335,7 @@ class TinyAuthorize extends BaseAuthorize {
 	 * @param Cake\Network\Request $request The request needing authorization.
 	 * @return array Hash with named keys for controller, plugin and prefix
 	 */
-	protected function constructIniKey(Request $request) {
+	protected function _constructIniKey(Request $request) {
 		$res = Inflector::camelize($request->params['controller']);
 		if (!empty($request->params['prefix'])) {
 			$res = strtolower($request->params['prefix']) . "/$res";

--- a/src/Auth/TinyAuthorize.php
+++ b/src/Auth/TinyAuthorize.php
@@ -43,7 +43,7 @@ class TinyAuthorize extends BaseAuthorize {
 
 	protected $_defaultConfig = [
 		'adminRole' => null, // needed together with adminPrefix if allowAdmin is enabled
-		'superAdminRole' => null, // quick way to allow access to every action
+		'superAdminRole' => null, // id of the role to grant access to ALL resources
 		'allowUser' => false, // quick way to allow user access to non prefixed urls
 		'allowAdmin' => false, // quick way to allow admin access to admin prefixed urls
 		'adminPrefix' => 'admin',
@@ -141,9 +141,8 @@ class TinyAuthorize extends BaseAuthorize {
 
 		// allow logged in super admins access to all resources
 		if (!empty($this->_config['superAdminRole'])) {
-			$superAdminRoleId = $availableRoles[$this->_config['superAdminRole']];
 			foreach ($roles as $role) {
-				if ($role == $superAdminRoleId) {
+				if ($role == $this->_config['superAdminRole']) {
 					return true;
 				}
 			}
@@ -287,7 +286,6 @@ class TinyAuthorize extends BaseAuthorize {
 				}
 			}
 		}
-		//pr($res);
 		Cache::write($this->_config['cacheKey'], $res, $this->_config['cache']);
 		return $res;
 	}

--- a/tests/TestCase/Auth/TinyAuthorizeTest.php
+++ b/tests/TestCase/Auth/TinyAuthorizeTest.php
@@ -648,35 +648,6 @@ INI;
 	}
 
 	/**
-	 * Should only be used in combination with Auth->allow() to mark those
-	 * as public in the acl.ini, as well. Not necessary and certainly not
-	 * recommended as acl.ini only.
-	 *
-	 * @todo: discuss, what is this??
-	 *
-	 * @return void
-	 */
-	// public function testBasicUserMethodAllowedPublically() {
-	// 	$object = new TestTinyAuthorize($this->Collection, ['autoClearCache' => true]);
-	//
-	// 	// test standard controller
-	// 	$this->request->params['controller'] = 'Tags';
-	// 	$this->request->params['action'] = 'add';
-	// 	$user = ['role_id' => 2];
-	// 	$res = $object->authorize($user, $this->request);
-	// 	$this->assertTrue($res);
-	//
-	// 	$this->request->params['controller'] = 'Comments';
-	// 	$this->request->params['action'] = 'foo';
-	//
-	// 	$user = [
-	// 		'role_id' => 3
-	// 	];
-	// 	$res = $object->authorize($user, $this->request);
-	// 	$this->assertTrue($res);
-	// }
-
-	/**
 	 * TinyAuthorizeTest::testWithRoleTable()
 	 *
 	 * @return void

--- a/tests/TestCase/Auth/TinyAuthorizeTest.php
+++ b/tests/TestCase/Auth/TinyAuthorizeTest.php
@@ -455,7 +455,6 @@ INI;
 			],
 		];
 
-
 		$user = [
 			'Roles' => [
 				['id' => 1, 'RoleUsers' => []],
@@ -832,6 +831,10 @@ INI;
 		$res = $method->invokeArgs($object, [$key]);
 		$this->assertEquals($expected, $res);
 
+		$key = 'users';	// test incorrect casing
+		$res = $method->invokeArgs($object, [$key]);
+		$this->assertNotEquals($expected, $res);
+
 		// Test standard controller with /admin prefix
 		$key = 'admin/Users';
 		$expected = [
@@ -841,6 +844,18 @@ INI;
 		];
 		$res = $method->invokeArgs($object, [$key]);
 		$this->assertEquals($expected, $res);
+
+		$key = 'admin/users';
+		$res = $method->invokeArgs($object, [$key]);
+		$this->assertNotEquals($expected, $res);
+
+		$key = 'Admin/users';
+		$res = $method->invokeArgs($object, [$key]);
+		$this->assertNotEquals($expected, $res);
+
+		$key = 'Admin/Users';
+		$res = $method->invokeArgs($object, [$key]);
+		$this->assertNotEquals($expected, $res);
 
 		// Test plugin controller without prefix
 		$key = 'Tags.Tags';
@@ -852,6 +867,18 @@ INI;
 		$res = $method->invokeArgs($object, [$key]);
 		$this->assertEquals($expected, $res);
 
+		$key = 'tags/tags';
+		$res = $method->invokeArgs($object, [$key]);
+		$this->assertNotEquals($expected, $res);
+
+		$key = 'tags/Tags';
+		$res = $method->invokeArgs($object, [$key]);
+		$this->assertNotEquals($expected, $res);
+
+		$key = 'Tags/tags';
+		$res = $method->invokeArgs($object, [$key]);
+		$this->assertNotEquals($expected, $res);
+
 		// Test plugin controller with /admin prefix
 		$key = 'Tags.admin/Tags';
 		$expected = [
@@ -861,8 +888,27 @@ INI;
 		];
 		$res = $method->invokeArgs($object, [$key]);
 		$this->assertEquals($expected, $res);
-	}
 
+		$key = 'tags.admin/tags';
+		$res = $method->invokeArgs($object, [$key]);
+		$this->assertNotEquals($expected, $res);
+
+		$key = 'tags.Admin/tags';
+		$res = $method->invokeArgs($object, [$key]);
+		$this->assertNotEquals($expected, $res);
+
+		$key = 'tags.admin/Tags';
+		$res = $method->invokeArgs($object, [$key]);
+		$this->assertNotEquals($expected, $res);
+
+		$key = 'Tags.Admin/Tags';
+		$res = $method->invokeArgs($object, [$key]);
+		$this->assertNotEquals($expected, $res);
+
+		$key = 'Tags.Admin/tags';
+		$res = $method->invokeArgs($object, [$key]);
+		$this->assertNotEquals($expected, $res);
+	}
 
 }
 

--- a/tests/TestCase/Auth/TinyAuthorizeTest.php
+++ b/tests/TestCase/Auth/TinyAuthorizeTest.php
@@ -690,6 +690,99 @@ INI;
 		}
 	}
 
+	/**
+	 * Tests constructing an ACL ini section key using CakeRequest parameters
+	 *
+	 * @return void
+	 */
+	public function testIniConstruct() {
+		// make protected function accessible
+		$object = new TestTinyAuthorize($this->Collection);
+		$reflection = new \ReflectionClass(get_class($object));
+		$method = $reflection->getMethod('_constructIniKey');
+		$method->setAccessible(true);
+
+		// test standard controller
+		$this->request->params['controller'] = 'Users';
+		$expected = 'Users';
+		$res =  $method->invokeArgs($object, [$this->request]);
+		$this->assertEquals($expected, $res);
+
+		// test standard controller with /admin prefix
+		$this->request->params['prefix'] = 'admin';
+		$expected = 'admin/Users';
+		$res =  $method->invokeArgs($object, [$this->request]);
+		$this->assertEquals($expected, $res);
+
+		// test plugin controller without prefix
+		$this->request->params['controller'] = 'Tags';
+		$this->request->params['plugin'] = 'Tags';
+		$this->request->params['prefix'] = null;
+		$expected = 'Tags.Tags';
+		$res =  $method->invokeArgs($object, [$this->request]);
+		$this->assertEquals($expected, $res);
+
+		// test plugin controller with /admin prefix
+		$this->request->params['prefix'] = 'admin';
+		$expected = 'Tags.admin/Tags';
+		$res =  $method->invokeArgs($object, [$this->request]);
+		$this->assertEquals($expected, $res);
+	}
+
+	/**
+	* Tests deconstructing an ACL ini section key
+	*
+	* @return void
+	*/
+	public function testIniDeconstruct() {
+		// make protected function accessible
+		$object = new TestTinyAuthorize($this->Collection);
+		$reflection = new \ReflectionClass(get_class($object));
+		$method = $reflection->getMethod('_deconstructIniKey');
+		$method->setAccessible(true);
+
+		// test standard controller
+		$key = 'Users';
+		$expected = [
+			'controller' => 'Users',
+			'plugin' => null,
+			'prefix' => null
+		];
+		$res = $method->invokeArgs($object, [$key]);
+		$this->assertEquals($expected, $res);
+
+		// test standard controller with /admin prefix
+		$key = 'admin/Users';
+		$expected = [
+			'controller' => 'Users',
+			'plugin' => null,
+			'prefix' => 'admin'
+		];
+		$res = $method->invokeArgs($object, [$key]);
+		$this->assertEquals($expected, $res);
+
+		// test plugin controller without prefix
+		$key = 'Tags.Tags';
+		$expected = [
+			'controller' => 'Tags',
+			'plugin' => 'Tags',
+			'prefix' => null
+		];
+		$res = $method->invokeArgs($object, [$key]);
+		$this->assertEquals($expected, $res);
+
+		// test plugin controller with /admin prefix
+		$key = 'Tags.admin/Tags';
+		$expected = [
+			'controller' => 'Tags',
+			'plugin' => 'Tags',
+			'prefix' => 'admin'
+		];
+		$res = $method->invokeArgs($object, [$key]);
+		$this->assertEquals($expected, $res);
+	}
+
+
 }
 
 class TestTinyAuthorize extends TinyAuthorize {

--- a/tests/TestCase/Auth/TinyAuthorizeTest.php
+++ b/tests/TestCase/Auth/TinyAuthorizeTest.php
@@ -38,37 +38,32 @@ class TinyAuthorizeTest extends TestCase {
 
 		$aclData = <<<INI
 ; ----------------------------------------------------------
-; Userscontroller (no prefixed route, no plugin)
-; ----------------------------------------------------------
-[Users]
-index = user, undefined-role
-edit = user
-delete = admin
-very_long_underscored_action = user
-veryLongActionNameAction = user
-public_action = public
-; ----------------------------------------------------------
-; UsersController (/admin prefixed route, no plugin)
-; ----------------------------------------------------------
-[admin/Users]
-index = user, undefined-role
-edit = user
-delete = admin
-public_action = public
-very_long_underscored_action = user
-veryLongActionNameAction = user
-; ----------------------------------------------------------
 ; TagsController (no prefixed route, no plugin)
 ; ----------------------------------------------------------
 [Tags]
-* = *
+index = user, undefined-role
+edit = user
+delete = admin
+very_long_underscored_action = user
+veryLongActionNameAction = user
+public_action = public
+; ----------------------------------------------------------
+; TagsController (/admin prefixed route, no plugin)
+; ----------------------------------------------------------
+[admin/Tags]
+index = user, undefined-role
+edit = user
+delete = admin
+very_long_underscored_action = user
+veryLongActionNameAction = user
+public_action = public
 ; ----------------------------------------------------------
 ; TagsController (plugin Tags, no prefixed route)
 ; ----------------------------------------------------------
 [Tags.Tags]
 index = user
 edit,view = user
-* = admin
+delete = admin
 public_action = public
 very_long_underscored_action = user
 veryLongActionNameAction = user
@@ -77,23 +72,21 @@ veryLongActionNameAction = user
 ; ----------------------------------------------------------
 [Tags.admin/Tags]
 index = user
-edit,view = user
-add = admin
+view, edit = user
+delete = admin
 public_action = public
 very_long_underscored_action = user
 veryLongActionNameAction = user
 ; ----------------------------------------------------------
-; CommentsController (no plugin, /special prefixed route)
+; CommentsController, used for testing 'allowUser' access to
+; non-admin-prefixed routes.
 ; ----------------------------------------------------------
 [special/Comments]
 * = admin
-; ----------------------------------------------------------
-; CommentsController (plugin Comments, /special prefixed route)
-; ----------------------------------------------------------
 [Comments.special/Comments]
 * = admin
 ; ----------------------------------------------------------
-; PostsController (for testing generic wildcard access)
+; PostsController, used for testing generic wildcard access
 ; ----------------------------------------------------------
 [Posts]
 *=*
@@ -104,7 +97,7 @@ veryLongActionNameAction = user
 [Posts.admin/Posts]
 * = *
 ; ----------------------------------------------------------
-; BlogsController (for testing specific wildcard access)
+; BlogsController, used for testing specific wildcard access
 ; ----------------------------------------------------------
 [Blogs]
 *= moderator
@@ -156,144 +149,136 @@ INI;
 		$res = $object->getAcl();
 
 		$expected = [
-			'Users' => [
-				'plugin' => null,
-				'prefix' => null,
-				'controller' => 'Users',
-				'actions' => [
-					'index' => [1],
-					'edit' => [1],
-					'delete' => [3],
-					'public_action' => [-1],
-					'very_long_underscored_action' => [1],
-					'veryLongActionNameAction' => [1]
-				]
-			],
-			'admin/Users' => [
-				'plugin' => null,
-				'prefix' => 'admin',
-				'controller' => 'Users',
-				'actions' => [
-					'index' => [1],
-					'edit' => [1],
-					'delete' => [3],
-					'public_action' => [-1],
-					'very_long_underscored_action' => [1],
-					'veryLongActionNameAction' => [1]
-				]
-			],
 			'Tags' => [
-				'plugin' => null,
-				'prefix' => null,
 				'controller' => 'Tags',
+				'prefix' => null,
+				'plugin' => null,
 				'actions' => [
-					'*' => [1, 2, 3, -1]
+					'index' => [1],
+					'edit' => [1],
+					'delete' => [3],
+					'public_action' => [-1],
+					'very_long_underscored_action' => [1],
+					'veryLongActionNameAction' => [1]
+				]
+			],
+			'admin/Tags' => [
+				'controller' => 'Tags',
+				'prefix' => 'admin',
+				'plugin' => null,
+				'actions' => [
+					'index' => [1],
+					'edit' => [1],
+					'delete' => [3],
+					'public_action' => [-1],
+					'very_long_underscored_action' => [1],
+					'veryLongActionNameAction' => [1]
 				]
 			],
 			'Tags.Tags' => [
-				'plugin' => 'Tags',
-				'prefix' => null,
 				'controller' => 'Tags',
+				'prefix' => null,
+				'plugin' => 'Tags',
 				'actions' => [
 					'index' => [1],
 					'edit' => [1],
 					'view' => [1],
-					'*' => [3],
+					'delete' => [3],
 					'public_action' => [-1],
 					'very_long_underscored_action' => [1],
 					'veryLongActionNameAction' => [1]
 				]
 			],
 			'Tags.admin/Tags' => [
-				'plugin' => 'Tags',
-				'prefix' => 'admin',
 				'controller' => 'Tags',
+				'prefix' => 'admin',
+				'plugin' => 'Tags',
 				'actions' => [
 					'index' => [1],
 					'edit' => [1],
 					'view' => [1],
-					'add' => [3],
+					'delete' => [3],
 					'public_action' => [-1],
 					'very_long_underscored_action' => [1],
 					'veryLongActionNameAction' => [1]
 				]
 			],
 			'special/Comments' => [
-				'plugin' => null,
-				'prefix' => 'special',
 				'controller' => 'Comments',
+				'prefix' => 'special',
+				'plugin' => null,
 				'actions' => [
 					'*' => [3]
 				]
 			],
 			'Comments.special/Comments' => [
-				'plugin' => 'Comments',
-				'prefix' => 'special',
 				'controller' => 'Comments',
+				'prefix' => 'special',
+				'plugin' => 'Comments',
 				'actions' => [
 					'*' => [3]
 				]
 			],
 			'Posts' => [
-				'plugin' => null,
-				'prefix' => null,
 				'controller' => 'Posts',
+				'prefix' => null,
+				'plugin' => null,
 				'actions' => [
 					'*' => [1, 2, 3, -1]
 				]
 			],
 			'admin/Posts' => [
-				'plugin' => null,
-				'prefix' => 'admin',
 				'controller' => 'Posts',
+				'prefix' => 'admin',
+				'plugin' => null,
 				'actions' => [
 					'*' => [1, 2, 3, -1]
 				]
 			],
 			'Posts.Posts' => [
-				'plugin' => 'Posts',
-				'prefix' => null,
 				'controller' => 'Posts',
+				'prefix' => null,
+				'plugin' => 'Posts',
 				'actions' => [
 					'*' => [1, 2, 3, -1]
 				]
 			],
 			'Posts.admin/Posts' => [
-				'plugin' => 'Posts',
-				'prefix' => 'admin',
 				'controller' => 'Posts',
+				'prefix' => 'admin',
+				'plugin' => 'Posts',
 				'actions' => [
 					'*' => [1, 2, 3, -1]
 				]
 			],
 			'Blogs' => [
-				'plugin' => null,
-				'prefix' => null,
 				'controller' => 'Blogs',
+				'prefix' => null,
+				'plugin' => null,
 				'actions' => [
 					'*' => [2]
 				]
 			],
 			'admin/Blogs' => [
-				'plugin' => null,
-				'prefix' => 'admin',
 				'controller' => 'Blogs',
+				'prefix' => 'admin',
+				'plugin' => null,
 				'actions' => [
 					'*' => [2]
 				]
 			],
 			'Blogs.Blogs' => [
-				'plugin' => 'Blogs',
-				'prefix' => null,
 				'controller' => 'Blogs',
+				'prefix' => null,
+				'plugin' => 'Blogs',
 				'actions' => [
 					'*' => [2]
 				]
 			],
 			'Blogs.admin/Blogs' => [
-				'plugin' => 'Blogs',
-				'prefix' => 'admin',
 				'controller' => 'Blogs',
+				'prefix' => 'admin',
+				'plugin' => 'Blogs',
 				'actions' => [
 					'*' => [2]
 				]
@@ -307,13 +292,20 @@ INI;
 	 * @return void
 	 */
 	public function testBasicUserMethodDisallowed() {
-		$object = new TestTinyAuthorize($this->Collection, ['autoClearCache' => true]);
+		$object = new TestTinyAuthorize($this->Collection, [
+			'autoClearCache' => true
+		]);
 		$this->assertEquals('Roles', $object->config('aclTable'));
 		$this->assertEquals('role_id', $object->config('aclKey'));
 
-		// Test standard controller
-		$this->request->params['controller'] = 'Users';
+		// All tests performed against this action
 		$this->request->params['action'] = 'add';
+
+		// Test standard controller
+		$this->request->params['controller'] = 'Tags';
+		$this->request->params['prefix'] = null;
+		$this->request->params['plugin'] = 'Tags';
+
 		$user = ['role_id' => 4]; // invalid non-existing role
 		$res = $object->authorize($user, $this->request);
 		$this->assertFalse($res);
@@ -323,7 +315,9 @@ INI;
 		$this->assertFalse($res);
 
 		// Test standard controller with /admin prefix
-		$this->request->params['prefix'] = 'admin';
+		$this->request->params['controller'] = 'Tags';
+		$this->request->params['prefix'] = null;
+		$this->request->params['plugin'] = null;
 
 		$user = ['role_id' => 4];
 		$res = $object->authorize($user, $this->request);
@@ -334,10 +328,9 @@ INI;
 		$this->assertFalse($res);
 
 		// Test plugin controller
-		$this->request->params['plugin'] = 'Tags';
 		$this->request->params['controller'] = 'Tags';
-		$this->request->params['action'] = 'add';
 		$this->request->params['prefix'] = null;
+		$this->request->params['plugin'] = 'Tags';
 
 		$user = ['role_id' => 4];
 		$res = $object->authorize($user, $this->request);
@@ -348,10 +341,9 @@ INI;
 		$this->assertFalse($res);
 
 		// Test plugin controller with /admin prefix
-		$this->request->params['plugin'] = 'Tags';
-		$this->request->params['prefix'] = 'admin';
 		$this->request->params['controller'] = 'Tags';
-		$this->request->params['action'] = 'add';
+		$this->request->params['prefix'] = 'admin';
+		$this->request->params['plugin'] = 'Tags';
 
 		$user = ['role_id' => 4];
 		$res = $object->authorize($user, $this->request);
@@ -366,12 +358,17 @@ INI;
 	 * @return void
 	 */
 	public function testBasicUserMethodAllowed() {
-		$object = new TestTinyAuthorize($this->Collection, ['autoClearCache' => true]);
+		$object = new TestTinyAuthorize($this->Collection, [
+			'autoClearCache' => true
+		]);
 
 		// Test standard controller
-		$this->request->params['controller'] = 'Users';
-		$this->request->params['action'] = 'edit';
+		$this->request->params['controller'] = 'Tags';
+		$this->request->params['prefix'] = null;
+		$this->request->params['plugin'] = null;
+
 		$user = [ 'role_id' => 1 ];
+		$this->request->params['action'] = 'edit';
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
 
@@ -381,10 +378,12 @@ INI;
 		$this->assertTrue($res);
 
 		// Test standard controller with /admin prefix
+		$this->request->params['controller'] = 'Tags';
 		$this->request->params['prefix'] = 'admin';
-		$this->request->params['action'] = 'edit';
+		$this->request->params['plugin'] = null;
 
 		$user = [ 'role_id' => 1 ];
+		$this->request->params['action'] = 'edit';
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
 
@@ -395,29 +394,31 @@ INI;
 
 		// Test plugin controller
 		$this->request->params['controller'] = 'Tags';
-		$this->request->params['plugin'] = 'Tags';
-		$this->request->params['action'] = 'index';
 		$this->request->params['prefix'] = null;
+		$this->request->params['plugin'] = 'Tags';
 
 		$user = ['role_id' => 1];
+		$this->request->params['action'] = 'edit';
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
 
 		$user = ['role_id' => 3];
-		$this->request->params['action'] = 'add';
+		$this->request->params['action'] = 'delete';
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
 
 		// Test plugin controller with /admin prefix
+		$this->request->params['controller'] = 'Tags';
 		$this->request->params['prefix'] = 'admin';
-		$this->request->params['action'] = 'index';
+		$this->request->params['plugin'] = 'Tags';
 
 		$user = ['role_id' => 1];
+		$this->request->params['action'] = 'edit';
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
 
 		$user = ['role_id' => 3];
-		$this->request->params['action'] = 'add';
+		$this->request->params['action'] = 'delete';
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
 	}
@@ -428,17 +429,27 @@ INI;
 	 * @return void
 	 */
 	public function testCaseSensitivity() {
-		$object = new TestTinyAuthorize($this->Collection, ['autoClearCache' => true]);
+		$object = new TestTinyAuthorize($this->Collection, [
+			'autoClearCache' => true]
+		);
+
+		// All tests performed against this action
+		$this->request->params['action'] = 'index';
 
 		// Test incorrect controller casing
-		$this->request->params['controller'] = 'users';
-		$this->request->params['action'] = 'index';
+		$this->request->params['controller'] = 'tags';
+		$this->request->params['prefix'] = null;
+		$this->request->params['plugin'] = null;
+
 		$user = [ 'role_id' => 1 ];
 		$res = $object->authorize($user, $this->request);
 		$this->assertFalse($res);
 
 		// Test incorrect controller casing with /admin prefix
+		$this->request->params['controller'] = 'tags';
 		$this->request->params['prefix'] = 'admin';
+		$this->request->params['plugin'] = null;
+
 		$user = [ 'role_id' => 1 ];
 		$res = $object->authorize($user, $this->request);
 		$this->assertFalse($res);
@@ -446,29 +457,35 @@ INI;
 		// Test correct controller casing with incorrect prefix casing
 		$this->request->params['controller'] = 'Users';
 		$this->request->params['prefix'] = 'Admin';
+		$this->request->params['plugin'] = null;
+
 		$user = [ 'role_id' => 1 ];
 		$res = $object->authorize($user, $this->request);
 		$this->assertFalse($res);
 
 		// Test incorrect plugin controller casing
 		$this->request->params['controller'] = 'tags';
-		$this->request->params['plugin'] = 'Tags';
 		$this->request->params['prefix'] = null;
+		$this->request->params['plugin'] = 'Tags';
+
 		$user = [ 'role_id' => 1 ];
 		$res = $object->authorize($user, $this->request);
 		$this->assertFalse($res);
 
 		// Test correct plugin controller with incorrect plugin casing
 		$this->request->params['controller'] = 'Tags';
+		$this->request->params['prefix'] = null;
 		$this->request->params['plugin'] = 'tags';
+
 		$user = [ 'role_id' => 1 ];
 		$res = $object->authorize($user, $this->request);
 		$this->assertFalse($res);
 
 		// Test correct plugin controller with correct plugin but incorrect prefix casing
 		$this->request->params['controller'] = 'Tags';
-		$this->request->params['plugin'] = 'Tags';
 		$this->request->params['prefix'] = 'Admin';
+		$this->request->params['plugin'] = 'Tags';
+
 		$user = [ 'role_id' => 1 ];
 		$res = $object->authorize($user, $this->request);
 		$this->assertFalse($res);
@@ -478,11 +495,17 @@ INI;
 	 * @return void
 	 */
 	public function testBasicUserMethodAllowedWithLongActionNames() {
-		$object = new TestTinyAuthorize($this->Collection, ['autoClearCache' => true]);
+		$object = new TestTinyAuthorize($this->Collection, [
+			'autoClearCache' => true
+		]);
+
+		// All tests performed against this action
+		$this->request->params['action'] = 'veryLongActionNameAction';
 
 		// Test standard controller
-		$this->request->params['controller'] = 'Users';
-		$this->request->params['action'] = 'veryLongActionNameAction';
+		$this->request->params['controller'] = 'Tags';
+		$this->request->params['prefix'] = null;
+		$this->request->params['plugin'] = null;
 
 		$user = ['role_id' => 1];
 		$res = $object->authorize($user, $this->request);
@@ -493,7 +516,10 @@ INI;
 		$this->assertFalse($res);
 
 		// Test standard controller with /admin prefix
+		$this->request->params['controller'] = 'Tags';
 		$this->request->params['prefix'] = 'admin';
+		$this->request->params['plugin'] = null;
+
 		$user = [ 'role_id' => 1 ];
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
@@ -504,8 +530,9 @@ INI;
 
 		// Test plugin controller
 		$this->request->params['controller'] = 'Tags';
-		$this->request->params['plugin'] = 'Tags';
 		$this->request->params['prefix'] = null;
+		$this->request->params['plugin'] = 'Tags';
+
 		$user = [ 'role_id' => 1 ];
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
@@ -515,7 +542,10 @@ INI;
 		$this->assertFalse($res);
 
 		// Test plugin controller with /admin prefix
+		$this->request->params['controller'] = 'Tags';
 		$this->request->params['prefix'] = 'admin';
+		$this->request->params['plugin'] = 'Tags';
+
 		$user = [ 'role_id' => 1 ];
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
@@ -529,11 +559,17 @@ INI;
 	 * @return void
 	 */
 	public function testBasicUserMethodAllowedWithLongActionNamesUnderscored() {
-		$object = new TestTinyAuthorize($this->Collection, ['autoClearCache' => true]);
+		$object = new TestTinyAuthorize($this->Collection, [
+			'autoClearCache' => true
+		]);
+
+		// All tests performed against this action
+		$this->request->params['action'] = 'very_long_underscored_action';
 
 		// Test standard controller
-		$this->request->params['controller'] = 'Users';
-		$this->request->params['action'] = 'very_long_underscored_action';
+		$this->request->params['controller'] = 'Tags';
+		$this->request->params['prefix'] = null;
+		$this->request->params['plugin'] = null;
 
 		$user = ['role_id' => 1];
 		$res = $object->authorize($user, $this->request);
@@ -544,7 +580,10 @@ INI;
 		$this->assertFalse($res);
 
 		// Test standard controller with /admin prefix
+		$this->request->params['controller'] = 'Tags';
 		$this->request->params['prefix'] = 'admin';
+		$this->request->params['plugin'] = null;
+
 		$user = [ 'role_id' => 1 ];
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
@@ -555,8 +594,9 @@ INI;
 
 		// Test plugin controller
 		$this->request->params['controller'] = 'Tags';
-		$this->request->params['plugin'] = 'Tags';
 		$this->request->params['prefix'] = null;
+		$this->request->params['plugin'] = 'Tags';
+
 		$user = [ 'role_id' => 1 ];
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
@@ -566,7 +606,10 @@ INI;
 		$this->assertFalse($res);
 
 		// Test plugin controller with /admin prefix
+		$this->request->params['controller'] = 'Tags';
 		$this->request->params['prefix'] = 'admin';
+		$this->request->params['plugin'] = 'Tags';
+
 		$user = [ 'role_id' => 1 ];
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
@@ -580,9 +623,11 @@ INI;
 	 * @return void
 	 */
 	public function testBasicUserMethodAllowedMultiRole() {
-		$object = new TestTinyAuthorize($this->Collection, ['autoClearCache' => true]);
+		$object = new TestTinyAuthorize($this->Collection, [
+			'autoClearCache' => true
+		]);
 
-		$this->request->params['controller'] = 'Users';
+		$this->request->params['controller'] = 'Tags';
 		$this->request->params['action'] = 'delete';
 
 		// Flat list of roles
@@ -623,9 +668,11 @@ INI;
 			'autoClearCache' => true
 		]);
 
-		// Test *=* for standard controller
-		$this->request->params['controller'] = 'Posts';
+		// All tests performed against this action
 		$this->request->params['action'] = 'any_action';
+
+		// Test standard controller
+		$this->request->params['controller'] = 'Posts';
 		$this->request->params['prefix'] = null;
 		$this->request->params['plugin'] = null;
 
@@ -675,12 +722,11 @@ INI;
 		$user = ['role_id' => 123];
 		$res = $object->authorize($user, $this->request);
 		$this->assertFalse($res);
-
 	}
 
 	/**
 	* Tests access to a controller that uses the * wildcard for the action
-	* but combines it with a specific group (e.g. * = moderators).
+	* but combines it with a specific group (here: * = moderators).
 	*
 	* @return void
 	*/
@@ -688,31 +734,15 @@ INI;
 		$object = new TestTinyAuthorize($this->Collection, [
 			'autoClearCache' => true
 		]);
-		$user = ['role_id' => 2];
 
-		// test standard controller
-		$this->request->params['controller'] = 'Blogs';
+		// All tests performed against this action
 		$this->request->params['action'] = 'any_action';
-		$res = $object->authorize($user, $this->request);
-		$this->assertTrue($res);
 
-		$user = ['role_id' => 3];
-		$res = $object->authorize($user, $this->request);
-		$this->assertFalse($res);
-
-		// test standard controller with /admin prefix
-		$this->request->params['prefix'] = 'admin';
-		$user = ['role_id' => 2];
-		$res = $object->authorize($user, $this->request);
-		$this->assertTrue($res);
-
-		$user = ['role_id' => 3];
-		$res = $object->authorize($user, $this->request);
-		$this->assertFalse($res);
-
-		// test plugin controlller
-		$this->request->params['plugin'] = 'Blogs';
+		// Test standard controller
+		$this->request->params['controller'] = 'Blogs';
 		$this->request->params['prefix'] = null;
+		$this->request->params['plugin'] = null;
+
 		$user = ['role_id' => 2];
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
@@ -721,8 +751,37 @@ INI;
 		$res = $object->authorize($user, $this->request);
 		$this->assertFalse($res);
 
-		// test plugin controlller with /admin prefix
+		// Test standard controller with /admin prefix
+		$this->request->params['controller'] = 'Blogs';
 		$this->request->params['prefix'] = 'admin';
+		$this->request->params['plugin'] = null;
+
+		$user = ['role_id' => 2];
+		$res = $object->authorize($user, $this->request);
+		$this->assertTrue($res);
+
+		$user = ['role_id' => 3];
+		$res = $object->authorize($user, $this->request);
+		$this->assertFalse($res);
+
+		// Test plugin controlller
+		$this->request->params['controller'] = 'Blogs';
+		$this->request->params['prefix'] = null;
+		$this->request->params['plugin'] = 'Blogs';
+
+		$user = ['role_id' => 2];
+		$res = $object->authorize($user, $this->request);
+		$this->assertTrue($res);
+
+		$user = ['role_id' => 3];
+		$res = $object->authorize($user, $this->request);
+		$this->assertFalse($res);
+
+		// Test plugin controlller with /admin prefix
+		$this->request->params['controller'] = 'Blogs';
+		$this->request->params['prefix'] = 'admin';
+		$this->request->params['plugin'] = 'Blogs';
+
 		$user = ['role_id' => 2];
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
@@ -737,19 +796,23 @@ INI;
 	 * Tests with configuration setting 'allowUser' set to true, giving user
 	 * access to all controller/actions except when prefixed with /admin
 	 *
-	 * @todo: discuss logic before completing, see code L120
-	 *
 	 * @return void
 	 */
 	public function testUserMethodsAllowed() {
 		$object = new TestTinyAuthorize($this->Collection, [
 			'allowUser' => true,
-			'autoClearCache' => true
+			'autoClearCache' => true,
+			'adminPrefix' => 'admin'
 		]);
 
+		// All tests performed against this action
+		$this->request->params['action'] = 'any_action';
+
 		// Test standard controller
-		$this->request->params['controller'] = 'Users';
-		$this->request->params['action'] = 'unknown_action';
+		$this->request->params['controller'] = 'Tags';
+		$this->request->params['prefix'] = null;
+		$this->request->params['plugin'] = null;
+
 		$user = ['role_id' => 1];
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
@@ -762,24 +825,29 @@ INI;
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
 
-		// Test standard controller with /admin prefix
+		// Test standard controller with /admin prefix. Note: users should NOT
+		// be allowed access here since the prefix matches the  'adminPrefix'
+		// configuration setting.
+		$this->request->params['controller'] = 'Tags';
 		$this->request->params['prefix'] = 'admin';
+		$this->request->params['plugin'] = null;
+
 		$user = ['role_id' => 1];
+		$res = $object->authorize($user, $this->request);
+		$this->assertFalse($res);
+
+		$user = ['role_id' => 2];
 		$res = $object->authorize($user, $this->request);
 		$this->assertFalse($res);
 
 		$user = ['role_id' => 3];
 		$res = $object->authorize($user, $this->request);
 		$this->assertFalse($res);
-
-		$this->request->params['action'] = 'delete';
-		$res = $object->authorize($user, $this->request);
-		$this->assertTrue($res);
 
 		// Test plugin controller
 		$this->request->params['controller'] = 'Tags';
-		$this->request->params['plugin'] = 'Tags';
 		$this->request->params['prefix'] = null;
+		$this->request->params['plugin'] = 'Tags';
 
 		$user = ['role_id' => 1];
 		$res = $object->authorize($user, $this->request);
@@ -789,31 +857,34 @@ INI;
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
 
-		$user = ['role_id' => 3]; // admin should be allowed
-		$res = $object->authorize($user, $this->request);
-		$this->assertTrue($res);
-
-		// Test plugin controller with /admin prefix
-		$this->request->params['prefix'] = 'admin';
-		$user = ['role_id' => 1];
-		$res = $object->authorize($user, $this->request);
-		$this->assertFalse($res);
-
-		$user = ['role_id' => 2];
-		$res = $object->authorize($user, $this->request);
-		$this->assertFalse($res);
-
-		$this->request->params['prefix'] = 'add';
 		$user = ['role_id' => 3];
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
 
-		// Users should have access to standard controller using non-admin prefix
+		// Test plugin controller with /admin prefix. Again: access should
+		// NOT be allowed because of matching 'adminPrefix'
+		$this->request->params['controller'] = 'Tags';
+		$this->request->params['prefix'] = 'admin';
+		$this->request->params['plugin'] = 'Tags';
+
+		$user = ['role_id' => 1];
+		$res = $object->authorize($user, $this->request);
+		$this->assertFalse($res);
+
+		$user = ['role_id' => 2];
+		$res = $object->authorize($user, $this->request);
+		$this->assertFalse($res);
+
+		$user = ['role_id' => 3];
+		$res = $object->authorize($user, $this->request);
+		$this->assertFalse($res);
+
+		// Test access to a standard controller using a prefix not matching the
+		// 'adminPrefix' => users should be allowed access.
 		$this->request->params['controller'] = 'Comments';
+		$this->request->params['prefix'] = 'special';
 		$this->request->params['plugin'] = null;
-		$this->request->params['prefix'] = 'special';
-		$this->request->params['prefix'] = 'admin';
-		$this->request->params['prefix'] = 'index';
+
 		$user = ['role_id' => 1];
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
@@ -826,10 +897,12 @@ INI;
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
 
-		// Users should have access to plugin controller using non-admin prefix
+		// Test access to a plugin controller using a prefix not matching the
+		// 'adminPrefix' => users should be allowed access.
 		$this->request->params['controller'] = 'Comments';
-		$this->request->params['plugin'] = 'Comments';
 		$this->request->params['prefix'] = 'special';
+		$this->request->params['plugin'] = 'Comments';
+
 		$user = ['role_id' => 1];
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
@@ -859,10 +932,14 @@ INI;
 		];
 		$object = new TestTinyAuthorize($this->Collection, $config);
 
+		// All tests performed against this action
+		$this->request->params['action'] = 'any_action';
+
 		// Test standard controller with /admin prefix
-		$this->request->params['controller'] = 'Users';
+		$this->request->params['controller'] = 'Tags';
 		$this->request->params['prefix'] = 'admin';
-		$this->request->params['action'] = 'some_action';
+		$this->request->params['plugin'] = null;
+
 		$user = ['role_id' => 1];
 		$res = $object->authorize($user, $this->request);
 		$this->assertFalse($res);
@@ -873,8 +950,9 @@ INI;
 
 		// Test plugin controller with /admin prefix
 		$this->request->params['controller'] = 'Tags';
+		$this->request->params['prefix'] = 'admin';
 		$this->request->params['plugin'] = 'Tags';
-		$this->request->params['prefix'] = null;
+
 		$user = ['role_id' => 1];
 		$res = $object->authorize($user, $this->request);
 		$this->assertFalse($res);
@@ -895,10 +973,12 @@ INI;
 
 		// We want the session to be used.
 		Configure::delete('Roles');
-		$object = new TestTinyAuthorize($this->Collection, ['autoClearCache' => true]);
+		$object = new TestTinyAuthorize($this->Collection, [
+			'autoClearCache' => true
+		]);
 
 		// test standard controller
-		$this->request->params['controller'] = 'Users';
+		$this->request->params['controller'] = 'Tags';
 		$this->request->params['action'] = 'edit';
 
 		// User role is 4 here, though. Also contains left joined Role date here just to check that it works, too.
@@ -991,27 +1071,37 @@ INI;
 		$method->setAccessible(true);
 
 		// Test standard controller
-		$this->request->params['controller'] = 'Users';
-		$expected = 'Users';
+		$this->request->params['controller'] = 'Tags';
+		$this->request->params['prefix'] = null;
+		$this->request->params['plugin'] = null;
+
+		$expected = 'Tags';
 		$res =  $method->invokeArgs($object, [$this->request]);
 		$this->assertEquals($expected, $res);
 
 		// Test standard controller with /admin prefix
+		$this->request->params['controller'] = 'Tags';
 		$this->request->params['prefix'] = 'admin';
-		$expected = 'admin/Users';
+		$this->request->params['plugin'] = null;
+
+		$expected = 'admin/Tags';
 		$res =  $method->invokeArgs($object, [$this->request]);
 		$this->assertEquals($expected, $res);
 
 		// Test plugin controller
 		$this->request->params['controller'] = 'Tags';
-		$this->request->params['plugin'] = 'Tags';
 		$this->request->params['prefix'] = null;
+		$this->request->params['plugin'] = 'Tags';
+
 		$expected = 'Tags.Tags';
 		$res =  $method->invokeArgs($object, [$this->request]);
 		$this->assertEquals($expected, $res);
 
 		// Test plugin controller with /admin prefix
+		$this->request->params['controller'] = 'Tags';
 		$this->request->params['prefix'] = 'admin';
+		$this->request->params['plugin'] = 'Tags';
+
 		$expected = 'Tags.admin/Tags';
 		$res =  $method->invokeArgs($object, [$this->request]);
 		$this->assertEquals($expected, $res);
@@ -1030,38 +1120,38 @@ INI;
 		$method->setAccessible(true);
 
 		// Test standard controller
-		$key = 'Users';
+		$key = 'Tags';
 		$expected = [
-			'controller' => 'Users',
+			'controller' => 'Tags',
 			'plugin' => null,
 			'prefix' => null
 		];
 		$res = $method->invokeArgs($object, [$key]);
 		$this->assertEquals($expected, $res);
 
-		$key = 'users';	// test incorrect casing
+		$key = 'tags';	// test incorrect casing
 		$res = $method->invokeArgs($object, [$key]);
 		$this->assertNotEquals($expected, $res);
 
 		// Test standard controller with /admin prefix
-		$key = 'admin/Users';
+		$key = 'admin/Tags';
 		$expected = [
-			'controller' => 'Users',
-			'plugin' => null,
-			'prefix' => 'admin'
+			'controller' => 'Tags',
+			'prefix' => 'admin',
+			'plugin' => null
 		];
 		$res = $method->invokeArgs($object, [$key]);
 		$this->assertEquals($expected, $res);
 
-		$key = 'admin/users';
+		$key = 'admin/tags';
 		$res = $method->invokeArgs($object, [$key]);
 		$this->assertNotEquals($expected, $res);
 
-		$key = 'Admin/users';
+		$key = 'Admin/tags';
 		$res = $method->invokeArgs($object, [$key]);
 		$this->assertNotEquals($expected, $res);
 
-		$key = 'Admin/Users';
+		$key = 'Admin/Tags';
 		$res = $method->invokeArgs($object, [$key]);
 		$this->assertNotEquals($expected, $res);
 
@@ -1069,8 +1159,8 @@ INI;
 		$key = 'Tags.Tags';
 		$expected = [
 			'controller' => 'Tags',
-			'plugin' => 'Tags',
-			'prefix' => null
+			'prefix' => null,
+			'plugin' => 'Tags'
 		];
 		$res = $method->invokeArgs($object, [$key]);
 		$this->assertEquals($expected, $res);
@@ -1091,8 +1181,8 @@ INI;
 		$key = 'Tags.admin/Tags';
 		$expected = [
 			'controller' => 'Tags',
-			'plugin' => 'Tags',
-			'prefix' => 'admin'
+			'prefix' => 'admin',
+			'plugin' => 'Tags'
 		];
 		$res = $method->invokeArgs($object, [$key]);
 		$this->assertEquals($expected, $res);

--- a/tests/TestCase/Auth/TinyAuthorizeTest.php
+++ b/tests/TestCase/Auth/TinyAuthorizeTest.php
@@ -75,11 +75,11 @@ very_long_action_name_action = user
 [Tags.admin/Tags]
 index = user
 edit,view = user
-* = admin
+add = admin
 public_action = public
 very_long_action_name_action = user
 ; ----------------------------------------------------------
-; CommentsController (plugin Comments, /special prefixed route)
+; CommentsController (no plugin, /special prefixed route)
 ; ----------------------------------------------------------
 [special/Comments]
 * = admin
@@ -154,19 +154,6 @@ INI;
 					'very_long_action_name_action' => [1]
 				]
 			],
-			// 'Comments' => [
-			// 	'plugin' => null,
-			// 	'prefix' => null,
-			// 	'controller' => 'Comments',
-			// 	'actions' => [
-			// 		'index' => [1],
-			// 		'edit' => [1],
-			// 		'view' => [1],
-			// 		'*' => [3],
-			// 		'public_action' => [-1],
-			// 		'very_long_action_name_action' => [1]
-			// 	]
-			// ],
 			'Tags' => [
 				'plugin' => null,
 				'prefix' => null,
@@ -196,7 +183,7 @@ INI;
 					'index' => [1],
 					'edit' => [1],
 					'view' => [1],
-					'*' => [3],
+					'add' => [3],
 					'public_action' => [-1],
 					'very_long_action_name_action' => [1]
 				]
@@ -230,7 +217,7 @@ INI;
 		$this->assertEquals('Roles', $object->config('aclTable'));
 		$this->assertEquals('role_id', $object->config('aclKey'));
 
-		// test standard controller
+		// Test standard controller
 		$this->request->params['controller'] = 'Users';
 		$this->request->params['action'] = 'add';
 		$user = ['role_id' => 4]; // invalid non-existing role
@@ -241,7 +228,7 @@ INI;
 		$res = $object->authorize($user, $this->request);
 		$this->assertFalse($res);
 
-		// test standard controller with /admin prefix
+		// Test standard controller with /admin prefix
 		$this->request->params['prefix'] = 'admin';
 
 		$user = ['role_id' => 4];
@@ -252,7 +239,7 @@ INI;
 		$res = $object->authorize($user, $this->request);
 		$this->assertFalse($res);
 
-		// test plugin controller
+		// Test plugin controller
 		$this->request->params['plugin'] = 'Tags';
 		$this->request->params['controller'] = 'Tags';
 		$this->request->params['action'] = 'add';
@@ -266,7 +253,7 @@ INI;
 		$res = $object->authorize($user, $this->request);
 		$this->assertFalse($res);
 
-		// test plugin controller with /admin prefix
+		// Test plugin controller with /admin prefix
 		$this->request->params['plugin'] = 'Tags';
 		$this->request->params['prefix'] = 'admin';
 		$this->request->params['controller'] = 'Tags';
@@ -287,7 +274,7 @@ INI;
 	public function testBasicUserMethodAllowed() {
 		$object = new TestTinyAuthorize($this->Collection, ['autoClearCache' => true]);
 
-		// test standard controller
+		// Test standard controller
 		$this->request->params['controller'] = 'Users';
 		$this->request->params['action'] = 'edit';
 		$user = [ 'role_id' => 1 ];
@@ -299,7 +286,7 @@ INI;
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
 
-		// test standard controller with /admin prefix
+		// Test standard controller with /admin prefix
 		$this->request->params['prefix'] = 'admin';
 		$this->request->params['action'] = 'edit';
 
@@ -312,7 +299,7 @@ INI;
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
 
-		// test plugin controller
+		// Test plugin controller
 		$this->request->params['controller'] = 'Tags';
 		$this->request->params['plugin'] = 'Tags';
 		$this->request->params['action'] = 'index';
@@ -323,11 +310,11 @@ INI;
 		$this->assertTrue($res);
 
 		$user = ['role_id' => 3];
-		$this->request->params['action'] = 'delete';
+		$this->request->params['action'] = 'add';
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
 
-		// test plugin controller with /admin prefix
+		// Test plugin controller with /admin prefix
 		$this->request->params['prefix'] = 'admin';
 		$this->request->params['action'] = 'index';
 
@@ -336,7 +323,7 @@ INI;
 		$this->assertTrue($res);
 
 		$user = ['role_id' => 3];
-		$this->request->params['action'] = 'delete';
+		$this->request->params['action'] = 'add';
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
 	}
@@ -349,27 +336,27 @@ INI;
 	public function testCaseSensitivity() {
 		$object = new TestTinyAuthorize($this->Collection, ['autoClearCache' => true]);
 
-		// test incorrect controller casing
+		// Test incorrect controller casing
 		$this->request->params['controller'] = 'users';
 		$this->request->params['action'] = 'index';
 		$user = [ 'role_id' => 1 ];
 		$res = $object->authorize($user, $this->request);
 		$this->assertFalse($res);
 
-		// test incorrect controller casing with /admin prefix
+		// Test incorrect controller casing with /admin prefix
 		$this->request->params['prefix'] = 'admin';
 		$user = [ 'role_id' => 1 ];
 		$res = $object->authorize($user, $this->request);
 		$this->assertFalse($res);
 
-		// test correct controller casing with incorrect prefix casing
+		// Test correct controller casing with incorrect prefix casing
 		$this->request->params['controller'] = 'Users';
 		$this->request->params['prefix'] = 'Admin';
 		$user = [ 'role_id' => 1 ];
 		$res = $object->authorize($user, $this->request);
 		$this->assertFalse($res);
 
-		// test incorrect plugin controller
+		// Test incorrect plugin controller casing
 		$this->request->params['controller'] = 'tags';
 		$this->request->params['plugin'] = 'Tags';
 		$this->request->params['prefix'] = null;
@@ -377,14 +364,14 @@ INI;
 		$res = $object->authorize($user, $this->request);
 		$this->assertFalse($res);
 
-		// test correct plugin controller with incorrect plugin casing
+		// Test correct plugin controller with incorrect plugin casing
 		$this->request->params['controller'] = 'Tags';
 		$this->request->params['plugin'] = 'tags';
 		$user = [ 'role_id' => 1 ];
 		$res = $object->authorize($user, $this->request);
 		$this->assertFalse($res);
 
-		// test correct plugin controller with correct plugin but incorrect prefix
+		// Test correct plugin controller with correct plugin but incorrect prefix casing
 		$this->request->params['controller'] = 'Tags';
 		$this->request->params['plugin'] = 'Tags';
 		$this->request->params['prefix'] = 'Admin';
@@ -399,7 +386,7 @@ INI;
 	public function testBasicUserMethodAllowedWithLongActionNames() {
 		$object = new TestTinyAuthorize($this->Collection, ['autoClearCache' => true]);
 
-		// test standard controller
+		// Test standard controller
 		$this->request->params['controller'] = 'Users';
 		$this->request->params['action'] = 'very_long_action_name_action';
 
@@ -411,7 +398,7 @@ INI;
 		$res = $object->authorize($user, $this->request);
 		$this->assertFalse($res);
 
-		// test standard controller with /admin prefix
+		// Test standard controller with /admin prefix
 		$this->request->params['prefix'] = 'admin';
 		$user = [ 'role_id' => 1 ];
 		$res = $object->authorize($user, $this->request);
@@ -421,7 +408,7 @@ INI;
 		$res = $object->authorize($user, $this->request);
 		$this->assertFalse($res);
 
-		// test plugin controller
+		// Test plugin controller
 		$this->request->params['controller'] = 'Tags';
 		$this->request->params['plugin'] = 'Tags';
 		$this->request->params['prefix'] = null;
@@ -433,7 +420,7 @@ INI;
 		$res = $object->authorize($user, $this->request);
 		$this->assertFalse($res);
 
-		// test plugin controller with /admin prefix
+		// Test plugin controller with /admin prefix
 		$this->request->params['prefix'] = 'admin';
 		$user = [ 'role_id' => 1 ];
 		$res = $object->authorize($user, $this->request);
@@ -453,14 +440,14 @@ INI;
 		$this->request->params['controller'] = 'Users';
 		$this->request->params['action'] = 'delete';
 
-		// flat list of roles
+		// Flat list of roles
 		$user = [
 			'Roles' => [1, 3]
 		];
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
 
-		// verbose role defition using the new 2.x contain param for Auth
+		// Verbose role defition using the new 2.x contain param for Auth
 		$user = [
 			'Roles' => [
 				['id' => 1, 'RoleUsers' => []],
@@ -486,25 +473,25 @@ INI;
 		$object = new TestTinyAuthorize($this->Collection, ['autoClearCache' => true]);
 		$user = ['role_id' => 6];
 
-		// test standard controller
+		// Test standard controller
 		$this->request->params['controller'] = 'Users';
 		$this->request->params['action'] = 'public_action';
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
 
-		// test standard controller with /admin prefiex
+		// Test standard controller with /admin prefix
 		$this->request->params['prefix'] = 'admin';
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
 
-		// test plugin controller
+		// Test plugin controller
 		$this->request->params['controller'] = 'Tags';
 		$this->request->params['plugin'] = 'Tags';
 		$this->request->params['prefix'] = null;
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
 
-		// test plugin controller with /admin prefix
+		// Test plugin controller with /admin prefix
 		$this->request->params['prefix'] = 'admin';
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
@@ -524,7 +511,7 @@ INI;
 			'autoClearCache' => true
 		]);
 
-		// test standard controller
+		// Test standard controller
 		$this->request->params['controller'] = 'Users';
 		$this->request->params['action'] = 'unknown_action';
 		$user = ['role_id' => 1];
@@ -580,6 +567,7 @@ INI;
 		$res = $object->authorize($user, $this->request);
 		$this->assertFalse($res);
 
+		$this->request->params['prefix'] = 'add';
 		$user = ['role_id' => 3];
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
@@ -588,6 +576,8 @@ INI;
 		$this->request->params['controller'] = 'Comments';
 		$this->request->params['plugin'] = null;
 		$this->request->params['prefix'] = 'special';
+		$this->request->params['prefix'] = 'admin';
+		$this->request->params['prefix'] = 'index';
 		$user = ['role_id' => 1];
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
@@ -633,7 +623,7 @@ INI;
 		];
 		$object = new TestTinyAuthorize($this->Collection, $config);
 
-		// test standard controller with /admin prefix
+		// Test standard controller with /admin prefix
 		$this->request->params['controller'] = 'Users';
 		$this->request->params['prefix'] = 'admin';
 		$this->request->params['action'] = 'some_action';
@@ -645,7 +635,7 @@ INI;
 		$res = $object->authorize($user, $this->request);
 		$this->assertTrue($res);
 
-		// test plugin controller with /admin prefix
+		// Test plugin controller with /admin prefix
 		$this->request->params['controller'] = 'Tags';
 		$this->request->params['plugin'] = 'Tags';
 		$this->request->params['prefix'] = null;
@@ -787,25 +777,25 @@ INI;
 	 * @return void
 	 */
 	public function testIniConstruct() {
-		// make protected function accessible
+		// Make protected function accessible
 		$object = new TestTinyAuthorize($this->Collection);
 		$reflection = new \ReflectionClass(get_class($object));
 		$method = $reflection->getMethod('_constructIniKey');
 		$method->setAccessible(true);
 
-		// test standard controller
+		// Test standard controller
 		$this->request->params['controller'] = 'Users';
 		$expected = 'Users';
 		$res =  $method->invokeArgs($object, [$this->request]);
 		$this->assertEquals($expected, $res);
 
-		// test standard controller with /admin prefix
+		// Test standard controller with /admin prefix
 		$this->request->params['prefix'] = 'admin';
 		$expected = 'admin/Users';
 		$res =  $method->invokeArgs($object, [$this->request]);
 		$this->assertEquals($expected, $res);
 
-		// test plugin controller without prefix
+		// Test plugin controller
 		$this->request->params['controller'] = 'Tags';
 		$this->request->params['plugin'] = 'Tags';
 		$this->request->params['prefix'] = null;
@@ -813,7 +803,7 @@ INI;
 		$res =  $method->invokeArgs($object, [$this->request]);
 		$this->assertEquals($expected, $res);
 
-		// test plugin controller with /admin prefix
+		// Test plugin controller with /admin prefix
 		$this->request->params['prefix'] = 'admin';
 		$expected = 'Tags.admin/Tags';
 		$res =  $method->invokeArgs($object, [$this->request]);
@@ -826,13 +816,13 @@ INI;
 	* @return void
 	*/
 	public function testIniDeconstruct() {
-		// make protected function accessible
+		// Make protected function accessible
 		$object = new TestTinyAuthorize($this->Collection);
 		$reflection = new \ReflectionClass(get_class($object));
 		$method = $reflection->getMethod('_deconstructIniKey');
 		$method->setAccessible(true);
 
-		// test standard controller
+		// Test standard controller
 		$key = 'Users';
 		$expected = [
 			'controller' => 'Users',
@@ -842,7 +832,7 @@ INI;
 		$res = $method->invokeArgs($object, [$key]);
 		$this->assertEquals($expected, $res);
 
-		// test standard controller with /admin prefix
+		// Test standard controller with /admin prefix
 		$key = 'admin/Users';
 		$expected = [
 			'controller' => 'Users',
@@ -852,7 +842,7 @@ INI;
 		$res = $method->invokeArgs($object, [$key]);
 		$this->assertEquals($expected, $res);
 
-		// test plugin controller without prefix
+		// Test plugin controller without prefix
 		$key = 'Tags.Tags';
 		$expected = [
 			'controller' => 'Tags',
@@ -862,7 +852,7 @@ INI;
 		$res = $method->invokeArgs($object, [$key]);
 		$this->assertEquals($expected, $res);
 
-		// test plugin controller with /admin prefix
+		// Test plugin controller with /admin prefix
 		$key = 'Tags.admin/Tags';
 		$expected = [
 			'controller' => 'Tags',

--- a/tests/TestCase/Auth/TinyAuthorizeTest.php
+++ b/tests/TestCase/Auth/TinyAuthorizeTest.php
@@ -1,13 +1,13 @@
 <?php
 namespace TinyAuth\Test\Auth;
 
-use TinyAuth\Auth\TinyAuthorize;
-use Cake\TestSuite\TestCase;
 use Cake\Controller\Controller;
 use Cake\Controller\ComponentRegistry;
-use Cake\Network\Request;
 use Cake\Core\Configure;
+use Cake\Network\Request;
 use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use TinyAuth\Auth\TinyAuthorize;
 
 /**
  * Test case for DirectAuthentication

--- a/tests/TestCase/Auth/TinyAuthorizeTest.php
+++ b/tests/TestCase/Auth/TinyAuthorizeTest.php
@@ -44,7 +44,7 @@ class TinyAuthorizeTest extends TestCase {
 index = user, undefined-role
 edit = user
 delete = admin
-very_long_action_name_action = user
+very_long_underscored_action = user
 veryLongActionNameAction = user
 public_action = public
 ; ----------------------------------------------------------
@@ -55,7 +55,7 @@ index = user, undefined-role
 edit = user
 delete = admin
 public_action = public
-very_long_action_name_action = user
+very_long_underscored_action = user
 veryLongActionNameAction = user
 ; ----------------------------------------------------------
 ; TagsController (no prefixed route, no plugin)
@@ -70,7 +70,7 @@ index = user
 edit,view = user
 * = admin
 public_action = public
-very_long_action_name_action = user
+very_long_underscored_action = user
 veryLongActionNameAction = user
 ; ----------------------------------------------------------
 ; TagsController (plugin Tags, /admin prefixed route)
@@ -80,7 +80,7 @@ index = user
 edit,view = user
 add = admin
 public_action = public
-very_long_action_name_action = user
+very_long_underscored_action = user
 veryLongActionNameAction = user
 ; ----------------------------------------------------------
 ; CommentsController (no plugin, /special prefixed route)
@@ -143,7 +143,7 @@ INI;
 					'edit' => [1],
 					'delete' => [3],
 					'public_action' => [-1],
-					'very_long_action_name_action' => [1],
+					'very_long_underscored_action' => [1],
 					'veryLongActionNameAction' => [1]
 				]
 			],
@@ -156,7 +156,7 @@ INI;
 					'edit' => [1],
 					'delete' => [3],
 					'public_action' => [-1],
-					'very_long_action_name_action' => [1],
+					'very_long_underscored_action' => [1],
 					'veryLongActionNameAction' => [1]
 				]
 			],
@@ -178,7 +178,7 @@ INI;
 					'view' => [1],
 					'*' => [3],
 					'public_action' => [-1],
-					'very_long_action_name_action' => [1],
+					'very_long_underscored_action' => [1],
 					'veryLongActionNameAction' => [1]
 				]
 			],
@@ -192,7 +192,7 @@ INI;
 					'view' => [1],
 					'add' => [3],
 					'public_action' => [-1],
-					'very_long_action_name_action' => [1],
+					'very_long_underscored_action' => [1],
 					'veryLongActionNameAction' => [1]
 				]
 			],
@@ -391,12 +391,12 @@ INI;
 	/**
 	 * @return void
 	 */
-	public function testBasicUserMethodAllowedWithLongActionNamesInflectedRoute() {
+	public function testBasicUserMethodAllowedWithLongActionNames() {
 		$object = new TestTinyAuthorize($this->Collection, ['autoClearCache' => true]);
 
 		// Test standard controller
 		$this->request->params['controller'] = 'Users';
-		$this->request->params['action'] = 'very_long_action_name_action';
+		$this->request->params['action'] = 'veryLongActionNameAction';
 
 		$user = ['role_id' => 1];
 		$res = $object->authorize($user, $this->request);
@@ -440,14 +440,14 @@ INI;
 	}
 
 	/**
-	* @return void
-	*/
-	public function testBasicUserMethodAllowedWithLongActionNamesDashedRoute() {
+	 * @return void
+	 */
+	public function testBasicUserMethodAllowedWithLongActionNamesUnderscored() {
 		$object = new TestTinyAuthorize($this->Collection, ['autoClearCache' => true]);
 
 		// Test standard controller
 		$this->request->params['controller'] = 'Users';
-		$this->request->params['action'] = 'veryLongActionNameAction';
+		$this->request->params['action'] = 'very_long_underscored_action';
 
 		$user = ['role_id' => 1];
 		$res = $object->authorize($user, $this->request);
@@ -840,10 +840,10 @@ INI;
 	}
 
 	/**
-	* Tests deconstructing an ACL ini section key
-	*
-	* @return void
-	*/
+	 * Tests deconstructing an ACL ini section key
+	 *
+	 * @return void
+	 */
 	public function testIniDeconstruct() {
 		// Make protected function accessible
 		$object = new TestTinyAuthorize($this->Collection);

--- a/tests/TestCase/Auth/TinyAuthorizeTest.php
+++ b/tests/TestCase/Auth/TinyAuthorizeTest.php
@@ -45,6 +45,7 @@ index = user, undefined-role
 edit = user
 delete = admin
 very_long_action_name_action = user
+veryLongActionNameAction = user
 public_action = public
 ; ----------------------------------------------------------
 ; UsersController (/admin prefixed route, no plugin)
@@ -55,6 +56,7 @@ edit = user
 delete = admin
 public_action = public
 very_long_action_name_action = user
+veryLongActionNameAction = user
 ; ----------------------------------------------------------
 ; TagsController (no prefixed route, no plugin)
 ; ----------------------------------------------------------
@@ -69,6 +71,7 @@ edit,view = user
 * = admin
 public_action = public
 very_long_action_name_action = user
+veryLongActionNameAction = user
 ; ----------------------------------------------------------
 ; TagsController (plugin Tags, /admin prefixed route)
 ; ----------------------------------------------------------
@@ -78,6 +81,7 @@ edit,view = user
 add = admin
 public_action = public
 very_long_action_name_action = user
+veryLongActionNameAction = user
 ; ----------------------------------------------------------
 ; CommentsController (no plugin, /special prefixed route)
 ; ----------------------------------------------------------
@@ -139,7 +143,8 @@ INI;
 					'edit' => [1],
 					'delete' => [3],
 					'public_action' => [-1],
-					'very_long_action_name_action' => [1]
+					'very_long_action_name_action' => [1],
+					'veryLongActionNameAction' => [1]
 				]
 			],
 			'admin/Users' => [
@@ -151,7 +156,8 @@ INI;
 					'edit' => [1],
 					'delete' => [3],
 					'public_action' => [-1],
-					'very_long_action_name_action' => [1]
+					'very_long_action_name_action' => [1],
+					'veryLongActionNameAction' => [1]
 				]
 			],
 			'Tags' => [
@@ -172,7 +178,8 @@ INI;
 					'view' => [1],
 					'*' => [3],
 					'public_action' => [-1],
-					'very_long_action_name_action' => [1]
+					'very_long_action_name_action' => [1],
+					'veryLongActionNameAction' => [1]
 				]
 			],
 			'Tags.admin/Tags' => [
@@ -185,7 +192,8 @@ INI;
 					'view' => [1],
 					'add' => [3],
 					'public_action' => [-1],
-					'very_long_action_name_action' => [1]
+					'very_long_action_name_action' => [1],
+					'veryLongActionNameAction' => [1]
 				]
 			],
 			'special/Comments' => [
@@ -383,12 +391,63 @@ INI;
 	/**
 	 * @return void
 	 */
-	public function testBasicUserMethodAllowedWithLongActionNames() {
+	public function testBasicUserMethodAllowedWithLongActionNamesInflectedRoute() {
 		$object = new TestTinyAuthorize($this->Collection, ['autoClearCache' => true]);
 
 		// Test standard controller
 		$this->request->params['controller'] = 'Users';
 		$this->request->params['action'] = 'very_long_action_name_action';
+
+		$user = ['role_id' => 1];
+		$res = $object->authorize($user, $this->request);
+		$this->assertTrue($res);
+
+		$user = ['role_id' => 2];
+		$res = $object->authorize($user, $this->request);
+		$this->assertFalse($res);
+
+		// Test standard controller with /admin prefix
+		$this->request->params['prefix'] = 'admin';
+		$user = [ 'role_id' => 1 ];
+		$res = $object->authorize($user, $this->request);
+		$this->assertTrue($res);
+
+		$user = ['role_id' => 2];
+		$res = $object->authorize($user, $this->request);
+		$this->assertFalse($res);
+
+		// Test plugin controller
+		$this->request->params['controller'] = 'Tags';
+		$this->request->params['plugin'] = 'Tags';
+		$this->request->params['prefix'] = null;
+		$user = [ 'role_id' => 1 ];
+		$res = $object->authorize($user, $this->request);
+		$this->assertTrue($res);
+
+		$user = ['role_id' => 2];
+		$res = $object->authorize($user, $this->request);
+		$this->assertFalse($res);
+
+		// Test plugin controller with /admin prefix
+		$this->request->params['prefix'] = 'admin';
+		$user = [ 'role_id' => 1 ];
+		$res = $object->authorize($user, $this->request);
+		$this->assertTrue($res);
+
+		$user = ['role_id' => 2];
+		$res = $object->authorize($user, $this->request);
+		$this->assertFalse($res);
+	}
+
+	/**
+	* @return void
+	*/
+	public function testBasicUserMethodAllowedWithLongActionNamesDashedRoute() {
+		$object = new TestTinyAuthorize($this->Collection, ['autoClearCache' => true]);
+
+		// Test standard controller
+		$this->request->params['controller'] = 'Users';
+		$this->request->params['action'] = 'veryLongActionNameAction';
 
 		$user = ['role_id' => 1];
 		$res = $object->authorize($user, $this->request);


### PR DESCRIPTION
Please review, if this is OK I will attempt to update the tests.

- supports the INI convention as [described here](https://gist.github.com/bravo-kernel/2a4c5df8785671ce86de)
- tested successfully for all scenarios in the INI above (plugins, prefixes, etc)
- major difference; I chose to generate a slightly more describing array for the acl since that could be useful for debugging, reporting, etc

Feedback welcome