### PR TITLE
New configuration keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,13 @@ Installing the plugin is pretty much as with every other CakePHP Plugin.
 composer require dereuromark/cakephp-tinyauth:dev-master
 ```
 
-Then load the plugin:
+Then, to load the plugin either run the following command:
+
+```sh
+bin/cake plugin load TinyAuth
+```
+
+or manually add the following line to your app's `config/bootstrap.php` file:
 
 ```php
 Plugin::load('TinyAuth');

--- a/README.md
+++ b/README.md
@@ -34,15 +34,7 @@ composer require dereuromark/cakephp-tinyauth:dev-master
 Then load the plugin:
 
 ```php
-Plugin::load('TinyAuth', ['bootstrap' => true]);
-```
-
-For `Plugin::loadAll()` it's
-
-```php
-Plugin::loadAll([
-		'TinyAuth' => ['bootstrap' => true]
-]);
+Plugin::load('TinyAuth');
 ```
 
 That's it. It should be up and running.

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,5 +1,0 @@
-<?php
-
-if (!defined('CLASS_USER')) {
-	define('CLASS_USER', 'Users');
-}

--- a/docs/README.md
+++ b/docs/README.md
@@ -205,9 +205,14 @@ TinyAuth supports the following configuration options.
 
 Option | Type | Description
 :----- | :--- | :----------
-roleColumn|string|Name of column in user table holding role id (only used for single-role per user/BT)
-roleAlias|string|Name of the column for the alias
+roleColumn|string|Name of column in user table holding role id (used for foreign key in users table in a single role per user setup, or in the pivot tableon multi-roles setups)
+userColumn|string|Name of column in pivot table holding role id (only used in pivot table on multi-roles setups)
+aliasColumn|string|Name of the column for the alias in the role table
 rolesTable|string|Name of Configure key holding all available roles OR class name of roles database table
+usersTable|string|Class name of the users table.
+pivotTable|string|Name of the pivot table, for a multi-group setup.
+rolesTablePlugin|string|Name of the plugin for the roles table, if any.
+pivotTablePlugin|string|Name of the plugin for the pivot table, if any.
 multiRole|boolean|True will enable multi-role/HABTM authorization (requires a valid join table)
 superAdminRole|int|Id of the super admin role. Users with this role will have access to ALL resources.
 authorizeByPrefix|boolean|If prefixed routes should be auto-handled by their matching role name.

--- a/docs/README.md
+++ b/docs/README.md
@@ -107,11 +107,13 @@ When using the single-role-per-user model TinyAuth expects your Users model to
 contain an column named ``role_id``. If you prefer to use another column name
 simply specify it using the ``roleColumn`` configuration option.
 
+The ``roleColumn`` option is also used on pivot table in a multi-role setup.
+
 ### Multi-role
 When using the multiple-roles-per-user model:
 
 - your database MUST have a ``roles`` table
-- your database MUST have a valid join table (e.g. ``roles_users``)
+- your database MUST have a valid join table (e.g. ``user_roles``, by default, it's constructed with users table first in the name). This can be overriden with the ``pivotTable`` option.
 - the configuration option ``multiRole`` MUST be set to ``true``
 
 Example of a record from a valid join table:

--- a/docs/README.md
+++ b/docs/README.md
@@ -113,7 +113,7 @@ The ``roleColumn`` option is also used on pivot table in a multi-role setup.
 When using the multiple-roles-per-user model:
 
 - your database MUST have a ``roles`` table
-- your database MUST have a valid join table (e.g. ``user_roles``, by default, it's constructed with users table first in the name). This can be overriden with the ``pivotTable`` option.
+- your database MUST have a valid join table (e.g. ``users_roles``). This can be overriden with the ``pivotTable`` option.
 - the configuration option ``multiRole`` MUST be set to ``true``
 
 Example of a record from a valid join table:

--- a/docs/README.md
+++ b/docs/README.md
@@ -113,7 +113,7 @@ The ``roleColumn`` option is also used on pivot table in a multi-role setup.
 When using the multiple-roles-per-user model:
 
 - your database MUST have a ``roles`` table
-- your database MUST have a valid join table (e.g. ``users_roles``). This can be overriden with the ``pivotTable`` option.
+- your database MUST have a valid join table (e.g. ``users_roles``). This can be overridden with the ``pivotTable`` option.
 - the configuration option ``multiRole`` MUST be set to ``true``
 
 Example of a record from a valid join table:

--- a/src/Auth/TinyAuthorize.php
+++ b/src/Auth/TinyAuthorize.php
@@ -333,8 +333,8 @@ class TinyAuthorize extends BaseAuthorize {
 		$rolesTable = TableRegistry::get($roleTable);
 
 		$roles = $rolesTable->find('all')->formatResults(function ($results) {
-					return $results->combine($this->_config['aliasColumn'], 'id');
-				})->toArray();
+			return $results->combine($this->_config['aliasColumn'], 'id');
+		})->toArray();
 
 		if (!count($roles)) {
 			throw new Exception('Invalid TinyAuthorize Role Setup (rolesTable has no roles)');

--- a/src/Auth/TinyAuthorize.php
+++ b/src/Auth/TinyAuthorize.php
@@ -67,7 +67,7 @@ class TinyAuthorize extends BaseAuthorize {
 	 * @throws \Cake\Core\Exception\Exception
 	 */
 	public function __construct(ComponentRegistry $registry, array $config = []) {
-		$config += (array) Configure::read('TinyAuth');
+		$config += (array)Configure::read('TinyAuth');
 		$config += $this->_defaultConfig;
 		if (!$config['prefixes'] && !empty($config['authorizeByPrefix'])) {
 			throw new Exception('Invalid TinyAuthorization setup for `authorizeByPrefix`. Please declare `prefixes`.');
@@ -147,7 +147,7 @@ class TinyAuthorize extends BaseAuthorize {
 		if (isset($this->_acl[$iniKey]['actions']['*'])) {
 			$matchArray = $this->_acl[$iniKey]['actions']['*'];
 			foreach ($userRoles as $userRole) {
-				if (in_array((string) $userRole, $matchArray)) {
+				if (in_array((string)$userRole, $matchArray)) {
 					return true;
 				}
 			}
@@ -158,7 +158,7 @@ class TinyAuthorize extends BaseAuthorize {
 			if (array_key_exists($request->action, $this->_acl[$iniKey]['actions']) && !empty($this->_acl[$iniKey]['actions'][$request->action])) {
 				$matchArray = $this->_acl[$iniKey]['actions'][$request->action];
 				foreach ($userRoles as $userRole) {
-					if (in_array((string) $userRole, $matchArray)) {
+					if (in_array((string)$userRole, $matchArray)) {
 						return true;
 					}
 				}

--- a/src/Auth/TinyAuthorize.php
+++ b/src/Auth/TinyAuthorize.php
@@ -383,9 +383,9 @@ class TinyAuthorize extends BaseAuthorize {
 		$pivotTable = TableRegistry::get($pivotTableName);
 		$roleColumn = $this->_config['roleColumn'];
 		$roles = $pivotTable->find('all', [
-					'conditions' => [$this->_config['userColumn'] => $user['id']],
-					'fields' => $roleColumn
-				])->extract($roleColumn)->toArray();
+			'conditions' => [$this->_config['userColumn'] => $user['id']],
+			'fields' => $roleColumn
+		])->extract($roleColumn)->toArray();
 
 		if (!count($roles)) {
 			throw new Exception('Missing TinyAuthorize roles for user in pivot table');

--- a/src/Auth/TinyAuthorize.php
+++ b/src/Auth/TinyAuthorize.php
@@ -41,7 +41,7 @@ class TinyAuthorize extends BaseAuthorize {
 
 	protected $_defaultConfig = [
 		'roleColumn' => 'role_id', // name of column in users table holding role id (used for single role/BT only)
-		'userColumn' => 'user_id', 
+		'userColumn' => 'user_id',
 		'aliasColumn' => 'alias', // name of column in roles table holding role alias/slug
 		'rolesTable' => 'Roles', // name of Configure key holding available roles OR class name of roles table
 		'usersTable' => 'Users', // name of the Users table
@@ -67,7 +67,7 @@ class TinyAuthorize extends BaseAuthorize {
 	 * @throws \Cake\Core\Exception\Exception
 	 */
 	public function __construct(ComponentRegistry $registry, array $config = []) {
-		$config += (array)Configure::read('TinyAuth');
+		$config += (array) Configure::read('TinyAuth');
 		$config += $this->_defaultConfig;
 		if (!$config['prefixes'] && !empty($config['authorizeByPrefix'])) {
 			throw new Exception('Invalid TinyAuthorization setup for `authorizeByPrefix`. Please declare `prefixes`.');
@@ -147,7 +147,7 @@ class TinyAuthorize extends BaseAuthorize {
 		if (isset($this->_acl[$iniKey]['actions']['*'])) {
 			$matchArray = $this->_acl[$iniKey]['actions']['*'];
 			foreach ($userRoles as $userRole) {
-				if (in_array((string)$userRole, $matchArray)) {
+				if (in_array((string) $userRole, $matchArray)) {
 					return true;
 				}
 			}
@@ -155,10 +155,10 @@ class TinyAuthorize extends BaseAuthorize {
 
 		// Allow access if user has been granted access to the specific resource
 		if (isset($this->_acl[$iniKey]['actions'])) {
-			if(array_key_exists($request->action, $this->_acl[$iniKey]['actions']) && !empty($this->_acl[$iniKey]['actions'][$request->action])) {
+			if (array_key_exists($request->action, $this->_acl[$iniKey]['actions']) && !empty($this->_acl[$iniKey]['actions'][$request->action])) {
 				$matchArray = $this->_acl[$iniKey]['actions'][$request->action];
 				foreach ($userRoles as $userRole) {
-					if (in_array((string)$userRole, $matchArray)) {
+					if (in_array((string) $userRole, $matchArray)) {
 						return true;
 					}
 				}
@@ -325,12 +325,16 @@ class TinyAuthorize extends BaseAuthorize {
 		}
 
 		// fetch roles from database
-		$rolesPlugin=$this->_config['rolesTablePlugin'];
-		$rolesTable = TableRegistry::get(((!$rolesPlugin)?$rolesPlugin.'.':'').$this->_config['rolesTable']);
+		$rolesPlugin = $this->_config['rolesTablePlugin'];
+		$roleTable = $this->_config['rolesTable'];
+		if (!$rolesPlugin) {
+			$roleTable = $rolesPlugin . '.' . $roleTable;
+		}
+		$rolesTable = TableRegistry::get($roleTable);
 
 		$roles = $rolesTable->find('all')->formatResults(function ($results) {
-			return $results->combine($this->_config['aliasColumn'], 'id');
-		})->toArray();
+					return $results->combine($this->_config['aliasColumn'], 'id');
+				})->toArray();
 
 		if (!count($roles)) {
 			throw new Exception('Invalid TinyAuthorize Role Setup (rolesTable has no roles)');
@@ -364,7 +368,7 @@ class TinyAuthorize extends BaseAuthorize {
 		$usersTableName = $this->_config['usersTable'];
 		if (!$pivotTableName) {
 			$tables = [
-				Inflector::singularize($usersTableName),
+				$usersTableName,
 				$rolesTableName
 			];
 			asort($tables);
@@ -372,13 +376,16 @@ class TinyAuthorize extends BaseAuthorize {
 		}
 
 		// fetch roles directly from the pivot table
-		$pivotTablePlugin=$this->_config['pivotTablePlugin'];
-		$pivotTable = TableRegistry::get(((!$pivotTablePlugin)?$pivotTablePlugin.'.':'').$pivotTableName);
+		$pivotTablePlugin = $this->_config['pivotTablePlugin'];
+		if (!$pivotTablePlugin) {
+			$pivotTableName = $pivotTablePlugin . '.' . $pivotTableName;
+		}
+		$pivotTable = TableRegistry::get($pivotTableName);
 		$roleColumn = $this->_config['roleColumn'];
 		$roles = $pivotTable->find('all', [
-			'conditions' => [$this->_config['userColumn'] => $user['id']],
-			'fields' => $roleColumn
-		])->extract($roleColumn)->toArray();
+					'conditions' => [$this->_config['userColumn'] => $user['id']],
+					'fields' => $roleColumn
+				])->extract($roleColumn)->toArray();
 
 		if (!count($roles)) {
 			throw new Exception('Missing TinyAuthorize roles for user in pivot table');

--- a/src/Auth/TinyAuthorize.php
+++ b/src/Auth/TinyAuthorize.php
@@ -11,9 +11,6 @@ use Cake\Network\Request;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
 
-if (!defined('CLASS_USERS')) {
-	define('CLASS_USERS', 'Users'); // override if you have it in a plugin: PluginName.Users etc
-}
 if (!defined('AUTH_CACHE')) {
 	define('AUTH_CACHE', '_cake_core_'); // use the most persistent cache by default
 }

--- a/tests/TestCase/Auth/TinyAuthorizeTest.php
+++ b/tests/TestCase/Auth/TinyAuthorizeTest.php
@@ -1410,7 +1410,7 @@ class TestTinyAuthorize extends TinyAuthorize {
 	 * @return Cake\ORM\Table The User table
 	 */
 	public function getTable() {
-		$Users = TableRegistry::get(CLASS_USERS);
+		$Users = TableRegistry::get($this->_config['usersTable']);
 		$Users->belongsTo('Roles');
 
 		return $Users;


### PR DESCRIPTION
Added some config keys to allow a simpler configuration through loadComponent and 
  - Changed the behaviour of undefined pivot tables(role plugin name, pivot table plugin name). 
  - Changed the behavior for undefined pivot tables : user_roles instead of roles_users (seems more logical _to me_, as users _have_ roles)
  - Updated the docs
  - removed the ``CLASS_USER`` constant : custom plugin is handled with the ``pivotTablePlugin`` option.

I can't run the tests as i'm not at home, but as far as I tried, it works.