### PR TITLE
Fix for wrong cache example configuration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -195,7 +195,7 @@ To disable caching either:
 - use the example below to disable caching automatically for CakePHP debug mode
 
 ```php
-'TinyAuth.Tiny' => [
+'TinyAuth' => [
 	'autoClearCache' => Configure::read('debug')
 ]
 ```


### PR DESCRIPTION
I have followed the docs and noticed that there was wrong example in Caching part. I have checked the __construct where config is set and it really seems it should be just TinyAuth instead of TinyAuth.Tiny.