### PR TITLE
Path correction and Testcase update

### DIFF
--- a/src/Auth/TinyAuthorize.php
+++ b/src/Auth/TinyAuthorize.php
@@ -170,7 +170,7 @@ class TinyAuthorize extends BaseAuthorize {
 		}
 
 		if ($this->_acl === null) {
-			$this->_acl = $this->_getAcl($this->_config['aclPath']);
+			$this->_acl = $this->_getAcl($this->_config['filePath']);
 		}
 
 		// Allow access if user has a role with wildcard access to the resource

--- a/tests/TestCase/Auth/TinyAuthorizeTest.php
+++ b/tests/TestCase/Auth/TinyAuthorizeTest.php
@@ -13,7 +13,8 @@ use Cake\Core\Plugin;
 /**
  * Test case for TinyAuth Authentication
  */
-class TinyAuthorizeTest extends TestCase {
+class TinyAuthorizeTest extends TestCase
+{
 
 	/**
 	 * @var array
@@ -40,84 +41,12 @@ class TinyAuthorizeTest extends TestCase {
 	/**
 	 * @return void
 	 */
-	public function setUp() {
+	public function setUp()
+	{
 		parent::setUp();
 
 		$this->collection = new ComponentRegistry();
-
 		$this->request = new Request();
-
-		$aclData = <<<INI
-; ----------------------------------------------------------
-; TagsController (no prefixed route, no plugin)
-; ----------------------------------------------------------
-[Tags]
-index = user, undefined-role
-edit = user
-delete = admin
-very_long_underscored_action = user
-veryLongActionNameAction = user
-; ----------------------------------------------------------
-; TagsController (/admin prefixed route, no plugin)
-; ----------------------------------------------------------
-[admin/Tags]
-index = user, undefined-role
-edit = user
-delete = admin
-very_long_underscored_action = user
-veryLongActionNameAction = user
-; ----------------------------------------------------------
-; TagsController (plugin Tags, no prefixed route)
-; ----------------------------------------------------------
-[Tags.Tags]
-index = user
-edit,view = user
-delete = admin
-very_long_underscored_action = user
-veryLongActionNameAction = user
-; ----------------------------------------------------------
-; TagsController (plugin Tags, /admin prefixed route)
-; ----------------------------------------------------------
-[Tags.admin/Tags]
-index = user
-view, edit = user
-delete = admin
-very_long_underscored_action = user
-veryLongActionNameAction = user
-; ----------------------------------------------------------
-; CommentsController, used for testing 'allowUser' access to
-; non-admin-prefixed routes.
-; ----------------------------------------------------------
-[special/Comments]
-* = admin
-[Comments.special/Comments]
-* = admin
-; ----------------------------------------------------------
-; PostsController, used for testing generic wildcard access
-; ----------------------------------------------------------
-[Posts]
-*=*
-[admin/Posts]
-* = *
-[Posts.Posts]
-* = *
-[Posts.admin/Posts]
-* = *
-; ----------------------------------------------------------
-; BlogsController, used for testing specific wildcard access
-; ----------------------------------------------------------
-[Blogs]
-*= moderator
-[admin/Blogs]
-* = moderator
-[Blogs.Blogs]
-* = moderator
-[Blogs.admin/Blogs]
-* = moderator
-INI;
-
-		file_put_contents(Plugin::path('TinyAuth') . 'tests' . DS . 'test_files' . DS . 'acl.ini', $aclData);
-		$this->assertTrue(file_exists(Plugin::path('TinyAuth') . 'tests' . DS . 'test_files' . DS . 'acl.ini'));
 
 		Configure::write('Roles', [
 			'user' => 1,
@@ -125,16 +54,10 @@ INI;
 			'admin' => 3
 		]);
 
-		Configure::write('TinyAuth', ['autoClearCache' => true]);
-	}
-
-	public function tearDown() {
-		unlink(Plugin::path('TinyAuth') . 'tests' . DS . 'test_files' . DS . 'acl.ini');
-		if (file_exists(Plugin::path('TinyAuth') . 'tests' . DS . 'test_files' . DS . 'acl.empty.ini')) {
-			unlink(Plugin::path('TinyAuth') . 'tests' . DS . 'test_files' . DS . 'acl.empty.ini');
-		}
-
-		parent::tearDown();
+		Configure::write('TinyAuth', [
+			'filePath' => Plugin::path('TinyAuth') . 'tests' . DS . 'test_files' . DS,
+			'autoClearCache' => true,
+		]);
 	}
 
 	/**
@@ -142,7 +65,8 @@ INI;
 	 *
 	 * @return void
 	 */
-	public function testConstructor() {
+	public function testConstructor()
+	{
 		$object = new TestTinyAuthorize($this->collection, [
 			'rolesTable' => 'AuthRoles',
 			'roleColumn' => 'auth_role_id',
@@ -157,7 +81,8 @@ INI;
 	 * @expectedException \Cake\Core\Exception\Exception
 	 * @return void
 	 */
-	public function testConstructorWithoutValidCache() {
+	public function testConstructorWithoutValidCache()
+	{
 		$object = new TestTinyAuthorize($this->collection, [
 			'cache' => 'invalid-cache-config'
 		]);
@@ -166,8 +91,11 @@ INI;
 	/**
 	 * @return void
 	 */
-	public function testGetAcl() {
-		$object = new TestTinyAuthorize($this->collection, ['autoClearCache' => true]);
+	public function testGetAcl()
+	{
+		$object = new TestTinyAuthorize($this->collection, [
+			'autoClearCache' => true
+		]);
 		$res = $object->getAcl();
 
 		$expected = [
@@ -312,7 +240,8 @@ INI;
 	/**
 	 * @return void
 	 */
-	public function testBasicUserMethodDisallowed() {
+	public function testBasicUserMethodDisallowed()
+	{
 		$object = new TestTinyAuthorize($this->collection, [
 			'autoClearCache' => true
 		]);
@@ -379,7 +308,8 @@ INI;
 	/**
 	 * @return void
 	 */
-	public function testBasicUserMethodAllowed() {
+	public function testBasicUserMethodAllowed()
+	{
 		$object = new TestTinyAuthorize($this->collection, [
 			'autoClearCache' => true
 		]);
@@ -450,9 +380,11 @@ INI;
 	 *
 	 * @return void
 	 */
-	public function testCaseSensitivity() {
+	public function testCaseSensitivity()
+	{
 		$object = new TestTinyAuthorize($this->collection, [
-			'autoClearCache' => true]);
+			'autoClearCache' => true
+		]);
 
 		// All tests performed against this action
 		$this->request->params['action'] = 'index';
@@ -515,7 +447,8 @@ INI;
 	/**
 	 * @return void
 	 */
-	public function testBasicUserMethodAllowedWithLongActionNames() {
+	public function testBasicUserMethodAllowedWithLongActionNames()
+	{
 		$object = new TestTinyAuthorize($this->collection, [
 			'autoClearCache' => true
 		]);
@@ -579,7 +512,8 @@ INI;
 	/**
 	 * @return void
 	 */
-	public function testBasicUserMethodAllowedWithLongActionNamesUnderscored() {
+	public function testBasicUserMethodAllowedWithLongActionNamesUnderscored()
+	{
 		$object = new TestTinyAuthorize($this->collection, [
 			'autoClearCache' => true
 		]);
@@ -645,12 +579,13 @@ INI;
 	 *
 	 * @return void
 	 */
-	public function testBasicUserMethodAllowedMultiRole() {
+	public function testBasicUserMethodAllowedMultiRole()
+	{
 		// Test against roles array in Configure
 		$object = new TestTinyAuthorize($this->collection, [
-			'multiRole' => true,
-			'rolesTable' => 'Roles',
 
+			'multiRole' => true,
+			'rolesTable' => 'Roles'
 		]);
 
 		$this->request->params['controller'] = 'Tags';
@@ -668,6 +603,7 @@ INI;
 
 		// Test against roles array in Database
 		$object = new TestTinyAuthorize($this->collection, [
+
 			'multiRole' => true,
 			'rolesTable' => 'DatabaseRoles',
 			'roleColumn' => 'database_role_id',
@@ -695,7 +631,8 @@ INI;
 	 *
 	 * @return void
 	 */
-	public function testBasicUserMethodAllowedWildcard() {
+	public function testBasicUserMethodAllowedWildcard()
+	{
 		$object = new TestTinyAuthorize($this->collection, [
 			'autoClearCache' => true
 		]);
@@ -762,7 +699,8 @@ INI;
 	 *
 	 * @return void
 	 */
-	public function testBasicUserMethodAllowedWildcardSpecificGroup() {
+	public function testBasicUserMethodAllowedWildcardSpecificGroup()
+	{
 		$object = new TestTinyAuthorize($this->collection, [
 			'autoClearCache' => true
 		]);
@@ -830,9 +768,11 @@ INI;
 	 *
 	 * @return void
 	 */
-	public function testUserMethodsAllowed() {
+	public function testUserMethodsAllowed()
+	{
 		$object = new TestTinyAuthorize($this->collection, [
 			'allowUser' => true,
+
 			'adminPrefix' => 'admin'
 		]);
 
@@ -955,7 +895,8 @@ INI;
 	 *
 	 * @return void
 	 */
-	public function testAdminMethodsAllowed() {
+	public function testAdminMethodsAllowed()
+	{
 		$config = [
 			'authorizeByPrefix' => true,
 			'adminRole' => 3,
@@ -999,8 +940,10 @@ INI;
 	 *
 	 * @return void
 	 */
-	public function testSuperAdminRole() {
+	public function testSuperAdminRole()
+	{
 		$object = new TestTinyAuthorize($this->collection, [
+
 			'superAdminRole' => 9
 		]);
 		$res = $object->getAcl();
@@ -1024,7 +967,8 @@ INI;
 	 *
 	 * @return void
 	 */
-	public function testIniParsing() {
+	public function testIniParsing()
+	{
 		$object = new TestTinyAuthorize($this->collection, [
 			'autoClearCache' => true
 		]);
@@ -1033,7 +977,9 @@ INI;
 		$reflection = new ReflectionClass(get_class($object));
 		$method = $reflection->getMethod('_parseFile');
 		$method->setAccessible(true);
-		$res = $method->invokeArgs($object, [TMP . 'acl.ini']);
+		$res = $method->invokeArgs($object, [
+			Plugin::path('TinyAuth') . 'tests' . DS . 'test_files' . DS . 'acl.ini'
+		]);
 		$this->assertTrue(is_array($res));
 	}
 
@@ -1043,7 +989,8 @@ INI;
 	 * @expectedException \Cake\Core\Exception\Exception
 	 * @return void
 	 */
-	public function testIniParsingMissingFileException() {
+	public function testIniParsingMissingFileException()
+	{
 		$object = new TestTinyAuthorize($this->collection, [
 			'autoClearCache' => true
 		]);
@@ -1060,7 +1007,8 @@ INI;
 	 *
 	 * @return void
 	 */
-	public function testIniConstruct() {
+	public function testIniConstruct()
+	{
 		// Make protected function accessible
 		$object = new TestTinyAuthorize($this->collection);
 		$reflection = new ReflectionClass(get_class($object));
@@ -1109,7 +1057,8 @@ INI;
 	 *
 	 * @return void
 	 */
-	public function testIniDeconstruct() {
+	public function testIniDeconstruct()
+	{
 		// Make protected function accessible
 		$object = new TestTinyAuthorize($this->collection);
 		$reflection = new ReflectionClass(get_class($object));
@@ -1210,8 +1159,10 @@ INI;
 	 *
 	 * @return void
 	 */
-	public function testAvailableRoles() {
+	public function testAvailableRoles()
+	{
 		$object = new TestTinyAuthorize($this->collection, [
+
 			'rolesTable' => 'Roles'
 		]);
 
@@ -1232,6 +1183,7 @@ INI;
 		// Test against roles from database
 		Configure::delete('Roles');
 		$object = new TestTinyAuthorize($this->collection, [
+
 			'rolesTable' => 'DatabaseRoles'
 		]);
 		$expected = [
@@ -1250,8 +1202,10 @@ INI;
 	 * @expectedException \Cake\Core\Exception\Exception
 	 * @return void
 	 */
-	public function testAvailableRolesMissingTableException() {
+	public function testAvailableRolesMissingTableException()
+	{
 		$object = new TestTinyAuthorize($this->collection, [
+
 			'rolesTable' => 'NonExistentTable'
 		]);
 
@@ -1269,8 +1223,10 @@ INI;
 	 * @expectedException \Cake\Core\Exception\Exception
 	 * @return void
 	 */
-	public function testAvailableRolesEmptyTableException() {
+	public function testAvailableRolesEmptyTableException()
+	{
 		$object = new TestTinyAuthorize($this->collection, [
+
 			'rolesTable' => 'EmptyRoles'
 		]);
 
@@ -1286,8 +1242,10 @@ INI;
 	 *
 	 * @return void
 	 */
-	public function testUserRoles() {
+	public function testUserRoles()
+	{
 		$object = new TestTinyAuthorize($this->collection, [
+
 			'multiRole' => false,
 			'roleColumn' => 'role_id'
 		]);
@@ -1304,7 +1262,6 @@ INI;
 
 		// Multi-role: lookup roles directly in pivot table
 		$object = new TestTinyAuthorize($this->collection, [
-
 			'multiRole' => true,
 			'rolesTable' => 'DatabaseRoles',
 			'roleColumn' => 'database_role_id',
@@ -1323,7 +1280,8 @@ INI;
 	 *
 	 * @return void
 	 */
-	public function testUserRolesCustomPivotTable() {
+	public function testUserRolesCustomPivotTable()
+	{
 		$object = new TestTinyAuthorize($this->collection, [
 			'multiRole' => true,
 			'rolesTable' => 'DatabaseRoles',
@@ -1350,7 +1308,8 @@ INI;
 	 *
 	 * @return void
 	 */
-	public function testIdColumnPivotTable() {
+	public function testIdColumnPivotTable()
+	{
 		$object = new TestTinyAuthorize($this->collection, [
 			'multiRole' => true,
 			'rolesTable' => 'DatabaseRoles',
@@ -1397,7 +1356,6 @@ INI;
 		];
 		$res = $method->invokeArgs($object, [$user]);
 		$this->assertEquals($expected, $res);
-
 	}
 
 	/**
@@ -1405,13 +1363,14 @@ INI;
 	 *
 	 * @return void
 	 */
-	public function testSuperAdmin() {
+	public function testSuperAdmin()
+	{
 		// All tests performed against this action
 		$this->request->params['action'] = 'any_action';
 		$this->request->params['controller'] = 'AnyControllers';
 		$this->request->params['prefix'] = null;
 		$this->request->params['plugin'] = null;
-		//single role
+		// Single role
 		$object = new TestTinyAuthorize($this->collection, [
 			'superAdmin' => 1,
 		]);
@@ -1586,7 +1545,8 @@ INI;
 	 * @expectedException \Cake\Core\Exception\Exception
 	 * @return void
 	 */
-	public function testUserRolesMissingRoleColumn() {
+	public function testUserRolesMissingRoleColumn()
+	{
 		$object = new TestTinyAuthorize($this->collection, [
 			'rolesTable' => 'NonExistentTable',
 			'multiRole' => false
@@ -1608,7 +1568,8 @@ INI;
 	 * @expectedException \Cake\Core\Exception\Exception
 	 * @return void
 	 */
-	public function testUserRolesUserWithoutPivotRoles() {
+	public function testUserRolesUserWithoutPivotRoles()
+	{
 		$object = new TestTinyAuthorize($this->collection, [
 			'rolesTable' => 'Roles',
 			'multiRole' => true
@@ -1623,15 +1584,16 @@ INI;
 		$res = $method->invokeArgs($object, [$user]);
 		$method->invoke($object);
 	}
-
 }
 
-class TestTinyAuthorize extends TinyAuthorize {
+class TestTinyAuthorize extends TinyAuthorize
+{
 
 	/**
 	 * @return array
 	 */
-	public function getAcl() {
+	public function getAcl()
+	{
 		return $this->_getAcl();
 	}
 
@@ -1640,7 +1602,8 @@ class TestTinyAuthorize extends TinyAuthorize {
 	 *
 	 * @return array
 	 */
-	protected function _getAcl($path = null) {
+	protected function _getAcl($path = null)
+	{
 		$path = Plugin::path('TinyAuth') . 'tests' . DS . 'test_files' . DS;
 		return parent::_getAcl($path);
 	}
@@ -1648,11 +1611,11 @@ class TestTinyAuthorize extends TinyAuthorize {
 	/**
 	 * @return \Cake\ORM\Table The User table
 	 */
-	public function getTable() {
+	public function getTable()
+	{
 		$Users = TableRegistry::get($this->_config['usersTable']);
 		$Users->belongsTo('Roles');
 
 		return $Users;
 	}
-
 }

--- a/tests/TestCase/Auth/TinyAuthorizeTest.php
+++ b/tests/TestCase/Auth/TinyAuthorizeTest.php
@@ -8,6 +8,7 @@ use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use ReflectionClass;
 use TinyAuth\Auth\TinyAuthorize;
+use Cake\Core\Plugin;
 
 /**
  * Test case for TinyAuth Authentication
@@ -115,8 +116,8 @@ veryLongActionNameAction = user
 * = moderator
 INI;
 
-		file_put_contents(TMP . 'acl.ini', $aclData);
-		$this->assertTrue(file_exists(TMP . 'acl.ini'));
+		file_put_contents(Plugin::path('TinyAuth') . 'tests' . DS . 'test_files' . DS . 'acl.ini', $aclData);
+		$this->assertTrue(file_exists(Plugin::path('TinyAuth') . 'tests' . DS . 'test_files' . DS . 'acl.ini'));
 
 		Configure::write('Roles', [
 			'user' => 1,
@@ -128,9 +129,9 @@ INI;
 	}
 
 	public function tearDown() {
-		unlink(TMP . 'acl.ini');
-		if (file_exists(TMP . 'acl.empty.ini')) {
-			unlink(TMP . 'acl.empty.ini');
+		unlink(Plugin::path('TinyAuth') . 'tests' . DS . 'test_files' . DS . 'acl.ini');
+		if (file_exists(Plugin::path('TinyAuth') . 'tests' . DS . 'test_files' . DS . 'acl.empty.ini')) {
+			unlink(Plugin::path('TinyAuth') . 'tests' . DS . 'test_files' . DS . 'acl.empty.ini');
 		}
 
 		parent::tearDown();
@@ -145,7 +146,6 @@ INI;
 		$object = new TestTinyAuthorize($this->collection, [
 			'rolesTable' => 'AuthRoles',
 			'roleColumn' => 'auth_role_id',
-
 		]);
 		$this->assertEquals('AuthRoles', $object->config('rolesTable'));
 		$this->assertEquals('auth_role_id', $object->config('roleColumn'));
@@ -648,9 +648,9 @@ INI;
 	public function testBasicUserMethodAllowedMultiRole() {
 		// Test against roles array in Configure
 		$object = new TestTinyAuthorize($this->collection, [
-
 			'multiRole' => true,
-			'rolesTable' => 'Roles'
+			'rolesTable' => 'Roles',
+
 		]);
 
 		$this->request->params['controller'] = 'Tags';
@@ -668,7 +668,6 @@ INI;
 
 		// Test against roles array in Database
 		$object = new TestTinyAuthorize($this->collection, [
-
 			'multiRole' => true,
 			'rolesTable' => 'DatabaseRoles',
 			'roleColumn' => 'database_role_id',
@@ -834,7 +833,6 @@ INI;
 	public function testUserMethodsAllowed() {
 		$object = new TestTinyAuthorize($this->collection, [
 			'allowUser' => true,
-
 			'adminPrefix' => 'admin'
 		]);
 
@@ -1003,7 +1001,6 @@ INI;
 	 */
 	public function testSuperAdminRole() {
 		$object = new TestTinyAuthorize($this->collection, [
-
 			'superAdminRole' => 9
 		]);
 		$res = $object->getAcl();
@@ -1215,7 +1212,6 @@ INI;
 	 */
 	public function testAvailableRoles() {
 		$object = new TestTinyAuthorize($this->collection, [
-
 			'rolesTable' => 'Roles'
 		]);
 
@@ -1236,7 +1232,6 @@ INI;
 		// Test against roles from database
 		Configure::delete('Roles');
 		$object = new TestTinyAuthorize($this->collection, [
-
 			'rolesTable' => 'DatabaseRoles'
 		]);
 		$expected = [
@@ -1257,7 +1252,6 @@ INI;
 	 */
 	public function testAvailableRolesMissingTableException() {
 		$object = new TestTinyAuthorize($this->collection, [
-
 			'rolesTable' => 'NonExistentTable'
 		]);
 
@@ -1277,7 +1271,6 @@ INI;
 	 */
 	public function testAvailableRolesEmptyTableException() {
 		$object = new TestTinyAuthorize($this->collection, [
-
 			'rolesTable' => 'EmptyRoles'
 		]);
 
@@ -1295,7 +1288,6 @@ INI;
 	 */
 	public function testUserRoles() {
 		$object = new TestTinyAuthorize($this->collection, [
-
 			'multiRole' => false,
 			'roleColumn' => 'role_id'
 		]);
@@ -1333,7 +1325,6 @@ INI;
 	 */
 	public function testUserRolesCustomPivotTable() {
 		$object = new TestTinyAuthorize($this->collection, [
-
 			'multiRole' => true,
 			'rolesTable' => 'DatabaseRoles',
 			'pivotTable' => 'DatabaseUserRoles',
@@ -1361,7 +1352,6 @@ INI;
 	 */
 	public function testIdColumnPivotTable() {
 		$object = new TestTinyAuthorize($this->collection, [
-
 			'multiRole' => true,
 			'rolesTable' => 'DatabaseRoles',
 			'pivotTable' => 'DatabaseUserRoles',
@@ -1494,7 +1484,6 @@ INI;
 
 		//multi role
 		$object = new TestTinyAuthorize($this->collection, [
-
 			'multiRole' => true,
 			'rolesTable' => 'DatabaseRoles',
 			'pivotTable' => 'DatabaseUserRoles',
@@ -1512,7 +1501,6 @@ INI;
 
 		//multi role and idColumn
 		$object = new TestTinyAuthorize($this->collection, [
-
 			'multiRole' => true,
 			'rolesTable' => 'DatabaseRoles',
 			'pivotTable' => 'DatabaseUserRoles',
@@ -1531,7 +1519,6 @@ INI;
 
 		//multi role and superAdminColumn
 		$object = new TestTinyAuthorize($this->collection, [
-
 			'multiRole' => true,
 			'rolesTable' => 'DatabaseRoles',
 			'pivotTable' => 'DatabaseUserRoles',
@@ -1552,7 +1539,6 @@ INI;
 
 		//multi role and superAdminColumn without idColumn
 		$object = new TestTinyAuthorize($this->collection, [
-
 			'multiRole' => true,
 			'rolesTable' => 'DatabaseRoles',
 			'pivotTable' => 'DatabaseUserRoles',
@@ -1571,7 +1557,6 @@ INI;
 		$this->assertFalse($res);
 		//single role and use superAdminColumn (string)
 		$object = new TestTinyAuthorize($this->collection, [
-
 			'multiRole' => true,
 			'rolesTable' => 'DatabaseRoles',
 			'pivotTable' => 'DatabaseUserRoles',
@@ -1603,7 +1588,6 @@ INI;
 	 */
 	public function testUserRolesMissingRoleColumn() {
 		$object = new TestTinyAuthorize($this->collection, [
-
 			'rolesTable' => 'NonExistentTable',
 			'multiRole' => false
 		]);
@@ -1626,7 +1610,6 @@ INI;
 	 */
 	public function testUserRolesUserWithoutPivotRoles() {
 		$object = new TestTinyAuthorize($this->collection, [
-
 			'rolesTable' => 'Roles',
 			'multiRole' => true
 		]);
@@ -1658,7 +1641,7 @@ class TestTinyAuthorize extends TinyAuthorize {
 	 * @return array
 	 */
 	protected function _getAcl($path = null) {
-		$path = TMP;
+		$path = Plugin::path('TinyAuth') . 'tests' . DS . 'test_files' . DS;
 		return parent::_getAcl($path);
 	}
 

--- a/tests/TestCase/Auth/TinyAuthorizeTest.php
+++ b/tests/TestCase/Auth/TinyAuthorizeTest.php
@@ -1549,6 +1549,7 @@ class TinyAuthorizeTest extends TestCase {
 		$res = $method->invokeArgs($object, [$user]);
 		$method->invoke($object);
 	}
+
 }
 
 class TestTinyAuthorize extends TinyAuthorize {
@@ -1579,4 +1580,5 @@ class TestTinyAuthorize extends TinyAuthorize {
 
 		return $Users;
 	}
+
 }

--- a/tests/TestCase/Auth/TinyAuthorizeTest.php
+++ b/tests/TestCase/Auth/TinyAuthorizeTest.php
@@ -3,18 +3,17 @@ namespace TinyAuth\Test\Auth;
 
 use Cake\Controller\ComponentRegistry;
 use Cake\Core\Configure;
+use Cake\Core\Plugin;
 use Cake\Network\Request;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use ReflectionClass;
 use TinyAuth\Auth\TinyAuthorize;
-use Cake\Core\Plugin;
 
 /**
  * Test case for TinyAuth Authentication
  */
-class TinyAuthorizeTest extends TestCase
-{
+class TinyAuthorizeTest extends TestCase {
 
 	/**
 	 * @var array
@@ -41,11 +40,11 @@ class TinyAuthorizeTest extends TestCase
 	/**
 	 * @return void
 	 */
-	public function setUp()
-	{
+	public function setUp() {
 		parent::setUp();
 
 		$this->collection = new ComponentRegistry();
+
 		$this->request = new Request();
 
 		Configure::write('Roles', [
@@ -65,11 +64,10 @@ class TinyAuthorizeTest extends TestCase
 	 *
 	 * @return void
 	 */
-	public function testConstructor()
-	{
+	public function testConstructor() {
 		$object = new TestTinyAuthorize($this->collection, [
 			'rolesTable' => 'AuthRoles',
-			'roleColumn' => 'auth_role_id',
+			'roleColumn' => 'auth_role_id'
 		]);
 		$this->assertEquals('AuthRoles', $object->config('rolesTable'));
 		$this->assertEquals('auth_role_id', $object->config('roleColumn'));
@@ -81,8 +79,7 @@ class TinyAuthorizeTest extends TestCase
 	 * @expectedException \Cake\Core\Exception\Exception
 	 * @return void
 	 */
-	public function testConstructorWithoutValidCache()
-	{
+	public function testConstructorWithoutValidCache() {
 		$object = new TestTinyAuthorize($this->collection, [
 			'cache' => 'invalid-cache-config'
 		]);
@@ -91,8 +88,7 @@ class TinyAuthorizeTest extends TestCase
 	/**
 	 * @return void
 	 */
-	public function testGetAcl()
-	{
+	public function testGetAcl() {
 		$object = new TestTinyAuthorize($this->collection, [
 			'autoClearCache' => true
 		]);
@@ -240,8 +236,7 @@ class TinyAuthorizeTest extends TestCase
 	/**
 	 * @return void
 	 */
-	public function testBasicUserMethodDisallowed()
-	{
+	public function testBasicUserMethodDisallowed() {
 		$object = new TestTinyAuthorize($this->collection, [
 			'autoClearCache' => true
 		]);
@@ -308,8 +303,7 @@ class TinyAuthorizeTest extends TestCase
 	/**
 	 * @return void
 	 */
-	public function testBasicUserMethodAllowed()
-	{
+	public function testBasicUserMethodAllowed() {
 		$object = new TestTinyAuthorize($this->collection, [
 			'autoClearCache' => true
 		]);
@@ -380,8 +374,7 @@ class TinyAuthorizeTest extends TestCase
 	 *
 	 * @return void
 	 */
-	public function testCaseSensitivity()
-	{
+	public function testCaseSensitivity() {
 		$object = new TestTinyAuthorize($this->collection, [
 			'autoClearCache' => true
 		]);
@@ -447,8 +440,7 @@ class TinyAuthorizeTest extends TestCase
 	/**
 	 * @return void
 	 */
-	public function testBasicUserMethodAllowedWithLongActionNames()
-	{
+	public function testBasicUserMethodAllowedWithLongActionNames() {
 		$object = new TestTinyAuthorize($this->collection, [
 			'autoClearCache' => true
 		]);
@@ -512,8 +504,7 @@ class TinyAuthorizeTest extends TestCase
 	/**
 	 * @return void
 	 */
-	public function testBasicUserMethodAllowedWithLongActionNamesUnderscored()
-	{
+	public function testBasicUserMethodAllowedWithLongActionNamesUnderscored() {
 		$object = new TestTinyAuthorize($this->collection, [
 			'autoClearCache' => true
 		]);
@@ -579,11 +570,9 @@ class TinyAuthorizeTest extends TestCase
 	 *
 	 * @return void
 	 */
-	public function testBasicUserMethodAllowedMultiRole()
-	{
+	public function testBasicUserMethodAllowedMultiRole() {
 		// Test against roles array in Configure
 		$object = new TestTinyAuthorize($this->collection, [
-
 			'multiRole' => true,
 			'rolesTable' => 'Roles'
 		]);
@@ -603,7 +592,6 @@ class TinyAuthorizeTest extends TestCase
 
 		// Test against roles array in Database
 		$object = new TestTinyAuthorize($this->collection, [
-
 			'multiRole' => true,
 			'rolesTable' => 'DatabaseRoles',
 			'roleColumn' => 'database_role_id',
@@ -631,8 +619,7 @@ class TinyAuthorizeTest extends TestCase
 	 *
 	 * @return void
 	 */
-	public function testBasicUserMethodAllowedWildcard()
-	{
+	public function testBasicUserMethodAllowedWildcard() {
 		$object = new TestTinyAuthorize($this->collection, [
 			'autoClearCache' => true
 		]);
@@ -699,8 +686,7 @@ class TinyAuthorizeTest extends TestCase
 	 *
 	 * @return void
 	 */
-	public function testBasicUserMethodAllowedWildcardSpecificGroup()
-	{
+	public function testBasicUserMethodAllowedWildcardSpecificGroup() {
 		$object = new TestTinyAuthorize($this->collection, [
 			'autoClearCache' => true
 		]);
@@ -768,11 +754,9 @@ class TinyAuthorizeTest extends TestCase
 	 *
 	 * @return void
 	 */
-	public function testUserMethodsAllowed()
-	{
+	public function testUserMethodsAllowed() {
 		$object = new TestTinyAuthorize($this->collection, [
 			'allowUser' => true,
-
 			'adminPrefix' => 'admin'
 		]);
 
@@ -895,8 +879,7 @@ class TinyAuthorizeTest extends TestCase
 	 *
 	 * @return void
 	 */
-	public function testAdminMethodsAllowed()
-	{
+	public function testAdminMethodsAllowed() {
 		$config = [
 			'authorizeByPrefix' => true,
 			'adminRole' => 3,
@@ -940,10 +923,8 @@ class TinyAuthorizeTest extends TestCase
 	 *
 	 * @return void
 	 */
-	public function testSuperAdminRole()
-	{
+	public function testSuperAdminRole() {
 		$object = new TestTinyAuthorize($this->collection, [
-
 			'superAdminRole' => 9
 		]);
 		$res = $object->getAcl();
@@ -967,8 +948,7 @@ class TinyAuthorizeTest extends TestCase
 	 *
 	 * @return void
 	 */
-	public function testIniParsing()
-	{
+	public function testIniParsing() {
 		$object = new TestTinyAuthorize($this->collection, [
 			'autoClearCache' => true
 		]);
@@ -989,8 +969,7 @@ class TinyAuthorizeTest extends TestCase
 	 * @expectedException \Cake\Core\Exception\Exception
 	 * @return void
 	 */
-	public function testIniParsingMissingFileException()
-	{
+	public function testIniParsingMissingFileException() {
 		$object = new TestTinyAuthorize($this->collection, [
 			'autoClearCache' => true
 		]);
@@ -1007,8 +986,7 @@ class TinyAuthorizeTest extends TestCase
 	 *
 	 * @return void
 	 */
-	public function testIniConstruct()
-	{
+	public function testIniConstruct() {
 		// Make protected function accessible
 		$object = new TestTinyAuthorize($this->collection);
 		$reflection = new ReflectionClass(get_class($object));
@@ -1057,8 +1035,7 @@ class TinyAuthorizeTest extends TestCase
 	 *
 	 * @return void
 	 */
-	public function testIniDeconstruct()
-	{
+	public function testIniDeconstruct() {
 		// Make protected function accessible
 		$object = new TestTinyAuthorize($this->collection);
 		$reflection = new ReflectionClass(get_class($object));
@@ -1159,10 +1136,8 @@ class TinyAuthorizeTest extends TestCase
 	 *
 	 * @return void
 	 */
-	public function testAvailableRoles()
-	{
+	public function testAvailableRoles() {
 		$object = new TestTinyAuthorize($this->collection, [
-
 			'rolesTable' => 'Roles'
 		]);
 
@@ -1183,7 +1158,6 @@ class TinyAuthorizeTest extends TestCase
 		// Test against roles from database
 		Configure::delete('Roles');
 		$object = new TestTinyAuthorize($this->collection, [
-
 			'rolesTable' => 'DatabaseRoles'
 		]);
 		$expected = [
@@ -1202,10 +1176,8 @@ class TinyAuthorizeTest extends TestCase
 	 * @expectedException \Cake\Core\Exception\Exception
 	 * @return void
 	 */
-	public function testAvailableRolesMissingTableException()
-	{
+	public function testAvailableRolesMissingTableException() {
 		$object = new TestTinyAuthorize($this->collection, [
-
 			'rolesTable' => 'NonExistentTable'
 		]);
 
@@ -1223,8 +1195,7 @@ class TinyAuthorizeTest extends TestCase
 	 * @expectedException \Cake\Core\Exception\Exception
 	 * @return void
 	 */
-	public function testAvailableRolesEmptyTableException()
-	{
+	public function testAvailableRolesEmptyTableException() {
 		$object = new TestTinyAuthorize($this->collection, [
 
 			'rolesTable' => 'EmptyRoles'
@@ -1242,8 +1213,7 @@ class TinyAuthorizeTest extends TestCase
 	 *
 	 * @return void
 	 */
-	public function testUserRoles()
-	{
+	public function testUserRoles() {
 		$object = new TestTinyAuthorize($this->collection, [
 
 			'multiRole' => false,
@@ -1280,8 +1250,7 @@ class TinyAuthorizeTest extends TestCase
 	 *
 	 * @return void
 	 */
-	public function testUserRolesCustomPivotTable()
-	{
+	public function testUserRolesCustomPivotTable() {
 		$object = new TestTinyAuthorize($this->collection, [
 			'multiRole' => true,
 			'rolesTable' => 'DatabaseRoles',
@@ -1308,8 +1277,7 @@ class TinyAuthorizeTest extends TestCase
 	 *
 	 * @return void
 	 */
-	public function testIdColumnPivotTable()
-	{
+	public function testIdColumnPivotTable() {
 		$object = new TestTinyAuthorize($this->collection, [
 			'multiRole' => true,
 			'rolesTable' => 'DatabaseRoles',
@@ -1363,8 +1331,7 @@ class TinyAuthorizeTest extends TestCase
 	 *
 	 * @return void
 	 */
-	public function testSuperAdmin()
-	{
+	public function testSuperAdmin() {
 		// All tests performed against this action
 		$this->request->params['action'] = 'any_action';
 		$this->request->params['controller'] = 'AnyControllers';
@@ -1545,8 +1512,7 @@ class TinyAuthorizeTest extends TestCase
 	 * @expectedException \Cake\Core\Exception\Exception
 	 * @return void
 	 */
-	public function testUserRolesMissingRoleColumn()
-	{
+	public function testUserRolesMissingRoleColumn() {
 		$object = new TestTinyAuthorize($this->collection, [
 			'rolesTable' => 'NonExistentTable',
 			'multiRole' => false
@@ -1568,8 +1534,7 @@ class TinyAuthorizeTest extends TestCase
 	 * @expectedException \Cake\Core\Exception\Exception
 	 * @return void
 	 */
-	public function testUserRolesUserWithoutPivotRoles()
-	{
+	public function testUserRolesUserWithoutPivotRoles() {
 		$object = new TestTinyAuthorize($this->collection, [
 			'rolesTable' => 'Roles',
 			'multiRole' => true
@@ -1586,14 +1551,12 @@ class TinyAuthorizeTest extends TestCase
 	}
 }
 
-class TestTinyAuthorize extends TinyAuthorize
-{
+class TestTinyAuthorize extends TinyAuthorize {
 
 	/**
 	 * @return array
 	 */
-	public function getAcl()
-	{
+	public function getAcl() {
 		return $this->_getAcl();
 	}
 
@@ -1602,8 +1565,7 @@ class TestTinyAuthorize extends TinyAuthorize
 	 *
 	 * @return array
 	 */
-	protected function _getAcl($path = null)
-	{
+	protected function _getAcl($path = null) {
 		$path = Plugin::path('TinyAuth') . 'tests' . DS . 'test_files' . DS;
 		return parent::_getAcl($path);
 	}
@@ -1611,8 +1573,7 @@ class TestTinyAuthorize extends TinyAuthorize
 	/**
 	 * @return \Cake\ORM\Table The User table
 	 */
-	public function getTable()
-	{
+	public function getTable() {
 		$Users = TableRegistry::get($this->_config['usersTable']);
 		$Users->belongsTo('Roles');
 

--- a/tests/test_files/acl.ini
+++ b/tests/test_files/acl.ini
@@ -1,0 +1,66 @@
+; ----------------------------------------------------------
+; TagsController (no prefixed route, no plugin)
+; ----------------------------------------------------------
+[Tags]
+index = user, undefined-role
+edit = user
+delete = admin
+very_long_underscored_action = user
+veryLongActionNameAction = user
+; ----------------------------------------------------------
+; TagsController (/admin prefixed route, no plugin)
+; ----------------------------------------------------------
+[admin/Tags]
+index = user, undefined-role
+edit = user
+delete = admin
+very_long_underscored_action = user
+veryLongActionNameAction = user
+; ----------------------------------------------------------
+; TagsController (plugin Tags, no prefixed route)
+; ----------------------------------------------------------
+[Tags.Tags]
+index = user
+edit,view = user
+delete = admin
+very_long_underscored_action = user
+veryLongActionNameAction = user
+; ----------------------------------------------------------
+; TagsController (plugin Tags, /admin prefixed route)
+; ----------------------------------------------------------
+[Tags.admin/Tags]
+index = user
+view, edit = user
+delete = admin
+very_long_underscored_action = user
+veryLongActionNameAction = user
+; ----------------------------------------------------------
+; CommentsController, used for testing 'allowUser' access to
+; non-admin-prefixed routes.
+; ----------------------------------------------------------
+[special/Comments]
+* = admin
+[Comments.special/Comments]
+* = admin
+; ----------------------------------------------------------
+; PostsController, used for testing generic wildcard access
+; ----------------------------------------------------------
+[Posts]
+*=*
+[admin/Posts]
+* = *
+[Posts.Posts]
+* = *
+[Posts.admin/Posts]
+* = *
+; ----------------------------------------------------------
+; BlogsController, used for testing specific wildcard access
+; ----------------------------------------------------------
+[Blogs]
+*= moderator
+[admin/Blogs]
+* = moderator
+[Blogs.Blogs]
+* = moderator
+[Blogs.admin/Blogs]
+* = moderator


### PR DESCRIPTION
TinyAuthorize::validate() need the correct _config key, trough BC
haven't been updated yet.
Now the TinyAuthorizeTest Class should use the "Plugin::path('TinyAuth')
. 'tests' . DS . 'test_files' . DS" instead of TMP folder.