### PR TITLE
Use acl adapters

### DIFF
--- a/src/Auth/AclAdapter/AclAdapterInterface.php
+++ b/src/Auth/AclAdapter/AclAdapterInterface.php
@@ -4,13 +4,13 @@ namespace TinyAuth\Auth\AclAdapter;
 
 interface AclAdapterInterface
 {
-    /**
-     * Generates and returns a TinyAuth access control list.
-     *
-     * @param array $availableRoles A list of available user roles.
-     * @param array $tinyConfig Current TinyAuth configuration values.
-     *
-     * @return array
-     */
-    public function getAcl($availableRoles, $tinyConfig);
+	/**
+	 * Generates and returns a TinyAuth access control list.
+	 *
+	 * @param array $availableRoles A list of available user roles.
+	 * @param array $tinyConfig Current TinyAuth configuration values.
+	 *
+	 * @return array
+	 */
+	public function getAcl($availableRoles, $tinyConfig);
 }

--- a/src/Auth/AclAdapter/AclAdapterInterface.php
+++ b/src/Auth/AclAdapter/AclAdapterInterface.php
@@ -13,4 +13,5 @@ interface AclAdapterInterface
 	 * @return array
 	 */
 	public function getAcl($availableRoles, $tinyConfig);
+
 }

--- a/src/Auth/AclAdapter/AclAdapterInterface.php
+++ b/src/Auth/AclAdapter/AclAdapterInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace TinyAuth\Auth\AclAdapter;
+
+interface AclAdapterInterface
+{
+    /**
+     * Generates and returns a TinyAuth access control list.
+     *
+     * @param array $availableRoles A list of available user roles.
+     * @param array $tinyConfig Current TinyAuth configuration values.
+     *
+     * @return array
+     */
+    public function getAcl($availableRoles, $tinyConfig);
+}

--- a/src/Auth/AclAdapter/AclAdapterInterface.php
+++ b/src/Auth/AclAdapter/AclAdapterInterface.php
@@ -12,6 +12,6 @@ interface AclAdapterInterface
 	 *
 	 * @return array
 	 */
-	public function getAcl($availableRoles, $tinyConfig);
+	public function getAcl(array $availableRoles, array $tinyConfig);
 
 }

--- a/src/Auth/AclAdapter/AclAdapterInterface.php
+++ b/src/Auth/AclAdapter/AclAdapterInterface.php
@@ -2,8 +2,7 @@
 
 namespace TinyAuth\Auth\AclAdapter;
 
-interface AclAdapterInterface
-{
+interface AclAdapterInterface {
 	/**
 	 * Generates and returns a TinyAuth access control list.
 	 *

--- a/src/Auth/AclAdapter/IniAclAdapter.php
+++ b/src/Auth/AclAdapter/IniAclAdapter.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace TinyAuth\Auth\AclAdapter;
+
+use TinyAuth\Utility\Utility;
+
+class IniAclAdapter implements AclAdapterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getAcl($availableRoles, $tinyConfig)
+    {
+        $iniArray = Utility::parseFiles($tinyConfig['filePath'], $tinyConfig['file']);
+
+        $res = [];
+        foreach ($iniArray as $key => $array) {
+            $res[$key] = Utility::deconstructIniKey($key);
+            $res[$key]['map'] = $array;
+
+            foreach ($array as $actions => $roles) {
+                // Get all roles used in the current INI section
+                $roles = explode(',', $roles);
+                $actions = explode(',', $actions);
+
+                foreach ($roles as $roleId => $role) {
+                    $role = trim($role);
+                    if (!$role) {
+                        continue;
+                    }
+                    // Prevent undefined roles appearing in the iniMap
+                    if (!array_key_exists($role, $availableRoles) && $role !== '*') {
+                        unset($roles[$roleId]);
+                        continue;
+                    }
+                    if ($role === '*') {
+                        unset($roles[$roleId]);
+                        $roles = array_merge($roles, array_keys($availableRoles));
+                    }
+                }
+
+                foreach ($actions as $action) {
+                    $action = trim($action);
+                    if (!$action) {
+                        continue;
+                    }
+
+                    foreach ($roles as $role) {
+                        $role = trim($role);
+                        if (!$role || $role === '*') {
+                            continue;
+                        }
+
+                        // Lookup role id by name in roles array
+                        $newRole = $availableRoles[strtolower($role)];
+                        $res[$key]['actions'][$action][] = $newRole;
+                    }
+                }
+            }
+        }
+
+        return $res;
+    }
+}

--- a/src/Auth/AclAdapter/IniAclAdapter.php
+++ b/src/Auth/AclAdapter/IniAclAdapter.php
@@ -4,13 +4,13 @@ namespace TinyAuth\Auth\AclAdapter;
 
 use TinyAuth\Utility\Utility;
 
-class IniAclAdapter implements AclAdapterInterface
-{
+class IniAclAdapter implements AclAdapterInterface {
 	/**
 	 * {@inheritdoc}
+	 *
+	 * @return array
 	 */
-	public function getAcl($availableRoles, $tinyConfig)
-	{
+	public function getAcl($availableRoles, $tinyConfig) {
 		$iniArray = Utility::parseFiles($tinyConfig['filePath'], $tinyConfig['file']);
 
 		$res = [];
@@ -61,4 +61,5 @@ class IniAclAdapter implements AclAdapterInterface
 
 		return $res;
 	}
+
 }

--- a/src/Auth/AclAdapter/IniAclAdapter.php
+++ b/src/Auth/AclAdapter/IniAclAdapter.php
@@ -6,59 +6,59 @@ use TinyAuth\Utility\Utility;
 
 class IniAclAdapter implements AclAdapterInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getAcl($availableRoles, $tinyConfig)
-    {
-        $iniArray = Utility::parseFiles($tinyConfig['filePath'], $tinyConfig['file']);
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getAcl($availableRoles, $tinyConfig)
+	{
+		$iniArray = Utility::parseFiles($tinyConfig['filePath'], $tinyConfig['file']);
 
-        $res = [];
-        foreach ($iniArray as $key => $array) {
-            $res[$key] = Utility::deconstructIniKey($key);
-            $res[$key]['map'] = $array;
+		$res = [];
+		foreach ($iniArray as $key => $array) {
+			$res[$key] = Utility::deconstructIniKey($key);
+			$res[$key]['map'] = $array;
 
-            foreach ($array as $actions => $roles) {
-                // Get all roles used in the current INI section
-                $roles = explode(',', $roles);
-                $actions = explode(',', $actions);
+			foreach ($array as $actions => $roles) {
+				// Get all roles used in the current INI section
+				$roles = explode(',', $roles);
+				$actions = explode(',', $actions);
 
-                foreach ($roles as $roleId => $role) {
-                    $role = trim($role);
-                    if (!$role) {
-                        continue;
-                    }
-                    // Prevent undefined roles appearing in the iniMap
-                    if (!array_key_exists($role, $availableRoles) && $role !== '*') {
-                        unset($roles[$roleId]);
-                        continue;
-                    }
-                    if ($role === '*') {
-                        unset($roles[$roleId]);
-                        $roles = array_merge($roles, array_keys($availableRoles));
-                    }
-                }
+				foreach ($roles as $roleId => $role) {
+					$role = trim($role);
+					if (!$role) {
+						continue;
+					}
+					// Prevent undefined roles appearing in the iniMap
+					if (!array_key_exists($role, $availableRoles) && $role !== '*') {
+						unset($roles[$roleId]);
+						continue;
+					}
+					if ($role === '*') {
+						unset($roles[$roleId]);
+						$roles = array_merge($roles, array_keys($availableRoles));
+					}
+				}
 
-                foreach ($actions as $action) {
-                    $action = trim($action);
-                    if (!$action) {
-                        continue;
-                    }
+				foreach ($actions as $action) {
+					$action = trim($action);
+					if (!$action) {
+						continue;
+					}
 
-                    foreach ($roles as $role) {
-                        $role = trim($role);
-                        if (!$role || $role === '*') {
-                            continue;
-                        }
+					foreach ($roles as $role) {
+						$role = trim($role);
+						if (!$role || $role === '*') {
+							continue;
+						}
 
-                        // Lookup role id by name in roles array
-                        $newRole = $availableRoles[strtolower($role)];
-                        $res[$key]['actions'][$action][] = $newRole;
-                    }
-                }
-            }
-        }
+						// Lookup role id by name in roles array
+						$newRole = $availableRoles[strtolower($role)];
+						$res[$key]['actions'][$action][] = $newRole;
+					}
+				}
+			}
+		}
 
-        return $res;
-    }
+		return $res;
+	}
 }

--- a/src/Auth/AclAdapter/IniAclAdapter.php
+++ b/src/Auth/AclAdapter/IniAclAdapter.php
@@ -10,7 +10,7 @@ class IniAclAdapter implements AclAdapterInterface {
 	 *
 	 * @return array
 	 */
-	public function getAcl($availableRoles, $tinyConfig) {
+	public function getAcl(array $availableRoles, array $tinyConfig) {
 		$iniArray = Utility::parseFiles($tinyConfig['filePath'], $tinyConfig['file']);
 
 		$res = [];

--- a/src/Auth/AclTrait.php
+++ b/src/Auth/AclTrait.php
@@ -7,8 +7,9 @@ use Cake\Core\Exception\Exception;
 use Cake\Datasource\ResultSetInterface;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
-use \InvalidArgumentException;
+use InvalidArgumentException;
 use TinyAuth\Auth\AclAdapter\AclAdapterInterface;
+use TinyAuth\Auth\AclAdapter\IniAclAdapter;
 use TinyAuth\Utility\Utility;
 
 trait AclTrait {
@@ -29,7 +30,7 @@ trait AclTrait {
 	protected $_userRoles = null;
 
 	/**
-	 * @var AclAdapterInterface|null
+	 * @var \TinyAuth\Auth\AclAdapter\AclAdapterInterface|null
 	 */
 	protected $_aclAdapter = null;
 
@@ -37,7 +38,7 @@ trait AclTrait {
 	 * @var array A map of acl adapter identifiers to their class names.
 	 */
 	protected $_aclAdaptersMap = [
-		'ini' => AclAdapter\IniAclAdapter::class
+		'ini' => IniAclAdapter::class
 	];
 
 	/**
@@ -100,12 +101,11 @@ trait AclTrait {
 	 *
 	 * @param string $adapter Acl adapter to load.
 	 *
-	 * @return AclAdapterInterface
+	 * @return \TinyAuth\Auth\AclAdapter\AclAdapterInterface
 	 *
-	 * @throws Exception
+	 * @throws \Cake\Core\Exception\Exception
 	 */
-	protected function _loadAclAdapter($adapter)
-	{
+	protected function _loadAclAdapter($adapter) {
 		if (array_key_exists($adapter, $this->_aclAdaptersMap)) {
 			$adapter = $this->_aclAdaptersMap[$adapter];
 		}
@@ -114,7 +114,7 @@ trait AclTrait {
 			throw new Exception(sprintf('The Acl Adapter class "%s" was not found.', $adapter));
 		}
 
-		$adapterInstance = new $adapter;
+		$adapterInstance = new $adapter();
 		if (!($adapterInstance instanceof AclAdapterInterface)) {
 			throw new InvalidArgumentException(sprintf(
 				'TinyAuth Acl adapters have to implement %s.', AclAdapterInterface::class
@@ -237,7 +237,7 @@ trait AclTrait {
 
 		// for BC
 		$config = $this->getConfig();
-		if (!is_null($path)) {
+		if (!($path === null)) {
 			$config['filePath'] = $path;
 		}
 		$roles = $this->_aclAdapter->getAcl($this->_getAvailableRoles(), $config);

--- a/src/Auth/AclTrait.php
+++ b/src/Auth/AclTrait.php
@@ -35,18 +35,11 @@ trait AclTrait {
 	protected $_aclAdapter = null;
 
 	/**
-	 * @var array A map of acl adapter identifiers to their class names.
-	 */
-	protected $_aclAdaptersMap = [
-		'ini' => IniAclAdapter::class
-	];
-
-	/**
 	 * @return array
 	 */
 	protected function _defaultConfig() {
 		$defaults = [
-			'aclAdapter' => 'ini',
+			'aclAdapter' => IniAclAdapter::class,
 			'idColumn' => 'id', // ID Column in users table
 			'roleColumn' => 'role_id', // Foreign key for the Role ID in users table or in pivot table
 			'userColumn' => 'user_id', // Foreign key for the User id in pivot table. Only for multi-roles setup
@@ -106,10 +99,6 @@ trait AclTrait {
 	 * @throws \Cake\Core\Exception\Exception
 	 */
 	protected function _loadAclAdapter($adapter) {
-		if (array_key_exists($adapter, $this->_aclAdaptersMap)) {
-			$adapter = $this->_aclAdaptersMap[$adapter];
-		}
-
 		if (!class_exists($adapter)) {
 			throw new Exception(sprintf('The Acl Adapter class "%s" was not found.', $adapter));
 		}

--- a/src/Auth/AclTrait.php
+++ b/src/Auth/AclTrait.php
@@ -28,24 +28,24 @@ trait AclTrait {
 	 */
 	protected $_userRoles = null;
 
-    /**
-     * @var AclAdapterInterface|null
-     */
+	/**
+	 * @var AclAdapterInterface|null
+	 */
 	protected $_aclAdapter = null;
 
-    /**
-     * @var array A map of acl adapter identifiers to their class names.
-     */
+	/**
+	 * @var array A map of acl adapter identifiers to their class names.
+	 */
 	protected $_aclAdaptersMap = [
-	    'ini' => AclAdapter\IniAclAdapter::class
-    ];
+		'ini' => AclAdapter\IniAclAdapter::class
+	];
 
 	/**
 	 * @return array
 	 */
 	protected function _defaultConfig() {
 		$defaults = [
-		    'aclAdapter' => 'ini',
+			'aclAdapter' => 'ini',
 			'idColumn' => 'id', // ID Column in users table
 			'roleColumn' => 'role_id', // Foreign key for the Role ID in users table or in pivot table
 			'userColumn' => 'user_id', // Foreign key for the User id in pivot table. Only for multi-roles setup
@@ -95,34 +95,34 @@ trait AclTrait {
 		return $config;
 	}
 
-    /**
-     * Finds the Acl adapter to use for this request.
-     *
-     * @param string $adapter Acl adapter to load.
-     *
-     * @return AclAdapterInterface
-     *
-     * @throws Exception
-     */
+	/**
+	 * Finds the Acl adapter to use for this request.
+	 *
+	 * @param string $adapter Acl adapter to load.
+	 *
+	 * @return AclAdapterInterface
+	 *
+	 * @throws Exception
+	 */
 	protected function _loadAclAdapter($adapter)
-    {
-        if (array_key_exists($adapter, $this->_aclAdaptersMap)) {
-            $adapter = $this->_aclAdaptersMap[$adapter];
-        }
+	{
+		if (array_key_exists($adapter, $this->_aclAdaptersMap)) {
+			$adapter = $this->_aclAdaptersMap[$adapter];
+		}
 
-        if (!class_exists($adapter)) {
-            throw new Exception(sprintf('The Acl Adapter class "%s" was not found.', $adapter));
-        }
+		if (!class_exists($adapter)) {
+			throw new Exception(sprintf('The Acl Adapter class "%s" was not found.', $adapter));
+		}
 
-        $adapterInstance = new $adapter;
-        if (!($adapterInstance instanceof AclAdapterInterface)) {
-            throw new InvalidArgumentException(sprintf(
-                'TinyAuth Acl adapters have to implement %s.', AclAdapterInterface::class
-            ));
-        }
+		$adapterInstance = new $adapter;
+		if (!($adapterInstance instanceof AclAdapterInterface)) {
+			throw new InvalidArgumentException(sprintf(
+				'TinyAuth Acl adapters have to implement %s.', AclAdapterInterface::class
+			));
+		}
 
-        return $adapterInstance;
-    }
+		return $adapterInstance;
+	}
 
 	/**
 	 * Checks the URL to the role(s).
@@ -236,10 +236,10 @@ trait AclTrait {
 		}
 
 		// for BC
-        $config = $this->getConfig();
+		$config = $this->getConfig();
 		if (!is_null($path)) {
-		    $config['filePath'] = $path;
-        }
+			$config['filePath'] = $path;
+		}
 		$roles = $this->_aclAdapter->getAcl($this->_getAvailableRoles(), $config);
 		Cache::write($this->getConfig('cacheKey'), $roles, $this->getConfig('cache'));
 

--- a/src/Utility/Utility.php
+++ b/src/Utility/Utility.php
@@ -27,6 +27,26 @@ class Utility {
 		return $res;
 	}
 
+    /**
+     * Returns the found INI file(s) as an array.
+     *
+     * @param array|string|null $paths Paths to look for INI files.
+     * @param string $file INI file name.
+     * @return array List with all found files.
+     */
+    public static function parseFiles($paths, $file) {
+        if ($paths === null) {
+            $paths = ROOT . DS . 'config' . DS;
+        }
+
+        $list = [];
+        foreach ((array)$paths as $path) {
+            $list += self::parseFile($path . $file);
+        }
+
+        return $list;
+    }
+
 	/**
 	 * Returns the ini file as an array.
 	 *

--- a/src/Utility/Utility.php
+++ b/src/Utility/Utility.php
@@ -27,25 +27,25 @@ class Utility {
 		return $res;
 	}
 
-    /**
-     * Returns the found INI file(s) as an array.
-     *
-     * @param array|string|null $paths Paths to look for INI files.
-     * @param string $file INI file name.
-     * @return array List with all found files.
-     */
-    public static function parseFiles($paths, $file) {
-        if ($paths === null) {
-            $paths = ROOT . DS . 'config' . DS;
-        }
+	/**
+	 * Returns the found INI file(s) as an array.
+	 *
+	 * @param array|string|null $paths Paths to look for INI files.
+	 * @param string $file INI file name.
+	 * @return array List with all found files.
+	 */
+	public static function parseFiles($paths, $file) {
+		if ($paths === null) {
+			$paths = ROOT . DS . 'config' . DS;
+		}
 
-        $list = [];
-        foreach ((array)$paths as $path) {
-            $list += self::parseFile($path . $file);
-        }
+		$list = [];
+		foreach ((array)$paths as $path) {
+			$list += self::parseFile($path . $file);
+		}
 
-        return $list;
-    }
+		return $list;
+	}
 
 	/**
 	 * Returns the ini file as an array.

--- a/src/Utility/Utility.php
+++ b/src/Utility/Utility.php
@@ -41,7 +41,7 @@ class Utility {
 
 		$list = [];
 		foreach ((array)$paths as $path) {
-			$list += self::parseFile($path . $file);
+			$list += static::parseFile($path . $file);
 		}
 
 		return $list;

--- a/tests/TestCase/Auth/TinyAuthorizeTest.php
+++ b/tests/TestCase/Auth/TinyAuthorizeTest.php
@@ -73,39 +73,39 @@ class TinyAuthorizeTest extends TestCase {
 		$this->assertEquals('auth_role_id', $object->getConfig('roleColumn'));
 	}
 
-    /**
-     * Tests loading a valid, custom acl adapter works.
-     *
-     * @return void
-     */
+	/**
+	 * Tests loading a valid, custom acl adapter works.
+	 *
+	 * @return void
+	 */
 	public function testLoadingAclAdapter() {
-	    $object = new TestTinyAuthorize($this->collection, [
-	        'aclAdapter' => CustomAclAdapter::class
-        ]);
-	    $this->assertInstanceOf(CustomAclAdapter::class, $object->getAclAdapter());
-    }
+		$object = new TestTinyAuthorize($this->collection, [
+			'aclAdapter' => CustomAclAdapter::class
+		]);
+		$this->assertInstanceOf(CustomAclAdapter::class, $object->getAclAdapter());
+	}
 
-    /**
-     * Tests loading an invalid acl adapter fails.
-     *
-     * @expectedException \InvalidArgumentException
-     */
-    public function testLoadingInvalidAclAdapter() {
-	    $object = new TestTinyAuthorize($this->collection, [
-	        'aclAdapter' => Configure::class
-        ]);
-    }
+	/**
+	 * Tests loading an invalid acl adapter fails.
+	 *
+	 * @expectedException \InvalidArgumentException
+	 */
+	public function testLoadingInvalidAclAdapter() {
+		$object = new TestTinyAuthorize($this->collection, [
+			'aclAdapter' => Configure::class
+		]);
+	}
 
-    /**
-     * Tests setting a non-existent class as the acl adapter fails.
-     *
-     * @expectedException \Cake\Core\Exception\Exception
-     */
-    public function testLoadingNonExistentAclAdapter() {
-        $object = new TestTinyAuthorize($this->collection, [
-            'aclAdapter' => 'Non\\Existent\\Acl\\Adapter'
-        ]);
-    }
+	/**
+	 * Tests setting a non-existent class as the acl adapter fails.
+	 *
+	 * @expectedException \Cake\Core\Exception\Exception
+	 */
+	public function testLoadingNonExistentAclAdapter() {
+		$object = new TestTinyAuthorize($this->collection, [
+			'aclAdapter' => 'Non\\Existent\\Acl\\Adapter'
+		]);
+	}
 
 	/**
 	 * Tests exception thrown when Cache is unavailable.
@@ -1316,8 +1316,8 @@ class TinyAuthorizeTest extends TestCase {
 		$method->setAccessible(true);
 
 		$user = [
-		'id' => 1,
-		'profile_id' => 2
+			'id' => 1,
+			'profile_id' => 2
 		];
 		$expected = [
 			'user' => 11,
@@ -1327,8 +1327,8 @@ class TinyAuthorizeTest extends TestCase {
 		$this->assertEquals($expected, $res);
 
 		$user = [
-		'id' => 1,
-		'profile_id' => 1
+			'id' => 1,
+			'profile_id' => 1
 		];
 		$expected = [
 			'user' => 11,
@@ -1339,7 +1339,7 @@ class TinyAuthorizeTest extends TestCase {
 
 		//without id
 		$user = [
-		'profile_id' => 1
+			'profile_id' => 1
 		];
 		$expected = [
 			'user' => 11,

--- a/tests/TestCase/Auth/TinyAuthorizeTest.php
+++ b/tests/TestCase/Auth/TinyAuthorizeTest.php
@@ -7,6 +7,7 @@ use Cake\Core\Plugin;
 use Cake\Network\Request;
 use Cake\TestSuite\TestCase;
 use ReflectionClass;
+use TestApp\Auth\AclAdapter\CustomAclAdapter;
 use TestApp\Auth\TestTinyAuthorize;
 
 /**
@@ -71,6 +72,29 @@ class TinyAuthorizeTest extends TestCase {
 		$this->assertEquals('AuthRoles', $object->getConfig('rolesTable'));
 		$this->assertEquals('auth_role_id', $object->getConfig('roleColumn'));
 	}
+
+    /**
+     * Tests loading a valid, custom acl adapter works.
+     *
+     * @return void
+     */
+	public function testLoadingAclAdapter() {
+	    $object = new TestTinyAuthorize($this->collection, [
+	        'aclAdapter' => CustomAclAdapter::class
+        ]);
+	    $this->assertInstanceOf(CustomAclAdapter::class, $object->getAclAdapter());
+    }
+
+    /**
+     * Tests loading an invalid acl adapter fails.
+     *
+     * @expectedException \Cake\Core\Exception\Exception
+     */
+    public function testLoadingInvalidAclAdapter() {
+	    $object = new TestTinyAuthorize($this->collection, [
+	        'aclAdapter' => Configure::class
+        ]);
+    }
 
 	/**
 	 * Tests exception thrown when Cache is unavailable.

--- a/tests/TestCase/Auth/TinyAuthorizeTest.php
+++ b/tests/TestCase/Auth/TinyAuthorizeTest.php
@@ -88,11 +88,22 @@ class TinyAuthorizeTest extends TestCase {
     /**
      * Tests loading an invalid acl adapter fails.
      *
-     * @expectedException \Cake\Core\Exception\Exception
+     * @expectedException \InvalidArgumentException
      */
     public function testLoadingInvalidAclAdapter() {
 	    $object = new TestTinyAuthorize($this->collection, [
 	        'aclAdapter' => Configure::class
+        ]);
+    }
+
+    /**
+     * Tests setting a non-existent class as the acl adapter fails.
+     *
+     * @expectedException \Cake\Core\Exception\Exception
+     */
+    public function testLoadingNonExistentAclAdapter() {
+        $object = new TestTinyAuthorize($this->collection, [
+            'aclAdapter' => 'Non\\Existent\\Acl\\Adapter'
         ]);
     }
 

--- a/tests/TestCase/Auth/TinyAuthorizeTest.php
+++ b/tests/TestCase/Auth/TinyAuthorizeTest.php
@@ -89,6 +89,7 @@ class TinyAuthorizeTest extends TestCase {
 	 * Tests loading an invalid acl adapter fails.
 	 *
 	 * @expectedException \InvalidArgumentException
+	 * @return void
 	 */
 	public function testLoadingInvalidAclAdapter() {
 		$object = new TestTinyAuthorize($this->collection, [
@@ -100,6 +101,7 @@ class TinyAuthorizeTest extends TestCase {
 	 * Tests setting a non-existent class as the acl adapter fails.
 	 *
 	 * @expectedException \Cake\Core\Exception\Exception
+	 * @return void
 	 */
 	public function testLoadingNonExistentAclAdapter() {
 		$object = new TestTinyAuthorize($this->collection, [

--- a/tests/test_app/Auth/AclAdapter/CustomAclAdapter.php
+++ b/tests/test_app/Auth/AclAdapter/CustomAclAdapter.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace TestApp\Auth\AclAdapter;
+
+use TinyAuth\Auth\AclAdapter\AclAdapterInterface;
+
+class CustomAclAdapter implements AclAdapterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getAcl($availableRoles, $tinyConfig)
+    {
+        return [];
+    }
+}

--- a/tests/test_app/Auth/AclAdapter/CustomAclAdapter.php
+++ b/tests/test_app/Auth/AclAdapter/CustomAclAdapter.php
@@ -4,13 +4,14 @@ namespace TestApp\Auth\AclAdapter;
 
 use TinyAuth\Auth\AclAdapter\AclAdapterInterface;
 
-class CustomAclAdapter implements AclAdapterInterface
-{
+class CustomAclAdapter implements AclAdapterInterface {
 	/**
 	 * {@inheritdoc}
+	 *
+	 * @return array
 	 */
-	public function getAcl($availableRoles, $tinyConfig)
-	{
+	public function getAcl($availableRoles, $tinyConfig) {
 		return [];
 	}
+
 }

--- a/tests/test_app/Auth/AclAdapter/CustomAclAdapter.php
+++ b/tests/test_app/Auth/AclAdapter/CustomAclAdapter.php
@@ -6,11 +6,11 @@ use TinyAuth\Auth\AclAdapter\AclAdapterInterface;
 
 class CustomAclAdapter implements AclAdapterInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getAcl($availableRoles, $tinyConfig)
-    {
-        return [];
-    }
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getAcl($availableRoles, $tinyConfig)
+	{
+		return [];
+	}
 }

--- a/tests/test_app/Auth/AclAdapter/CustomAclAdapter.php
+++ b/tests/test_app/Auth/AclAdapter/CustomAclAdapter.php
@@ -10,7 +10,7 @@ class CustomAclAdapter implements AclAdapterInterface {
 	 *
 	 * @return array
 	 */
-	public function getAcl($availableRoles, $tinyConfig) {
+	public function getAcl(array $availableRoles, array $tinyConfig) {
 		return [];
 	}
 

--- a/tests/test_app/Auth/TestTinyAuthorize.php
+++ b/tests/test_app/Auth/TestTinyAuthorize.php
@@ -7,12 +7,12 @@ use TinyAuth\Auth\TinyAuthorize;
 
 class TestTinyAuthorize extends TinyAuthorize {
 
-    /**
-     * @return null|\TinyAuth\Auth\AclAdapter\AclAdapterInterface
-     */
-    public function getAclAdapter() {
-        return $this->_aclAdapter;
-    }
+	/**
+	 * @return null|\TinyAuth\Auth\AclAdapter\AclAdapterInterface
+	 */
+	public function getAclAdapter() {
+		return $this->_aclAdapter;
+	}
 
 	/**
 	 * @return array

--- a/tests/test_app/Auth/TestTinyAuthorize.php
+++ b/tests/test_app/Auth/TestTinyAuthorize.php
@@ -7,6 +7,13 @@ use TinyAuth\Auth\TinyAuthorize;
 
 class TestTinyAuthorize extends TinyAuthorize {
 
+    /**
+     * @return null|\TinyAuth\Auth\AclAdapter\AclAdapterInterface
+     */
+    public function getAclAdapter() {
+        return $this->_aclAdapter;
+    }
+
 	/**
 	 * @return array
 	 */


### PR DESCRIPTION
This extends `AuthTrait::_getAcl()` to allow using acl adapters to load lists from data sources other than `acl.ini`.