### PR TITLE
Start Middleware and "Core plugins" support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 			"role": "Maintainer"
 		}
 	],
-	"require": {
+	"require":
 		"php": ">=5.6",
 		"cakephp/cakephp": "^3.7.0"
 	},

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 			"role": "Maintainer"
 		}
 	],
-	"require":
+	"require": {
 		"php": ">=5.6",
 		"cakephp/cakephp": "^3.7.0"
 	},

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,8 @@
 		"cakephp/cakephp": "^3.7.0"
 	},
 	"require-dev": {
+		"cakephp/authentication": "dev-master",
+		"cakephp/authorization": "dev-master",
 		"fig-r/psr2r-sniffer": "dev-master"
 	},
 	"support": {

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -119,6 +119,6 @@ Option | Type | Description
 :----- | :--- | :----------
 autoClearCache|bool|True will generate a new ACL cache file every time.
 cache|string|Cache type. Defaults to `_cake_core_`.
-allowCacheKey|string|Cache key. Defaults to `tiny_auth_allow`.
+allowCacheKey|string|Cache key. Defaults to `tinyauth_allow`.
 allowFilePath|string|Full path to the INI file. Can also be an array of paths. Defaults to `ROOT . DS . 'config' . DS`.
 allowFile|string|Name of the INI file. Defaults to `auth_allow.ini`.

--- a/docs/AuthenticationPlugin.md
+++ b/docs/AuthenticationPlugin.md
@@ -1,0 +1,11 @@
+### Authentication plugin support
+
+Support for [Authentication](https://github.com/cakephp/authentication) usage.
+
+Instead of the Auth component you load the Authentication one:
+
+```php
+$this->loadComponent('TinyAuth.Authentication', [
+    ...
+]);
+```

--- a/docs/AuthenticationPlugin.md
+++ b/docs/AuthenticationPlugin.md
@@ -1,6 +1,6 @@
 ### Authentication plugin support
 
-Support for [Authentication](https://github.com/cakephp/authentication) usage.
+Support for [Authentication plugin](https://github.com/cakephp/authentication) usage.
 
 Instead of the Auth component you load the Authentication one:
 
@@ -9,3 +9,7 @@ $this->loadComponent('TinyAuth.Authentication', [
     ...
 ]);
 ```
+
+For all the rest just follow the plugin's documentation.
+
+Then you use the [Authentication documention](Authentication.md) to fill your config file.

--- a/docs/Authorization.md
+++ b/docs/Authorization.md
@@ -339,6 +339,7 @@ bin/cake tiny_auth_sync {your default roles, comma separated}
 ```
 This will then add any missing controller with `* = ...` for all actions and you can then manually fine-tune.
 
+Note: Use `'*'` as wildcard role if you just want to generate all possible controllers.
 Use with `-d -v` to just output the changes it would do to your ACL INI file.
 
 ## Tips

--- a/docs/Authorization.md
+++ b/docs/Authorization.md
@@ -251,11 +251,11 @@ allowUser|bool|True will give authenticated users access to all resources except
 adminPrefix|string|Name of the prefix used for admin pages. Defaults to admin.
 autoClearCache|bool|True will generate a new ACL cache file every time.
 cache|string|Cache type. Defaults to `_cake_core_`.
-aclCacheKey|string|Cache key. Defaults to `tiny_auth_acl`.
+aclCacheKey|string|Cache key. Defaults to `tinyauth_acl`.
 aclFilePath|string|Full path to the acl.ini. Can also be an array of multiple paths. Defaults to `ROOT . DS . 'config' . DS`.
 aclFile|string|Name of the INI file. Defaults to `acl.ini`.
 includeAuthentication|bool|Set to true to include public auth access into hasAccess() checks. Note, that this requires Configure configuration.
-allowCacheKey|string|Cache key. Defaults to `tiny_auth_allow`. Needed to fetch allow info from the correct cache. Must be the same as set in AuthComponent.
+allowCacheKey|string|Cache key. Defaults to `tinyauth_allow`. Needed to fetch allow info from the correct cache. Must be the same as set in AuthComponent.
 
 ## AuthUserComponent
 Add the AuthUserComponent and you can easily check permissions inside your controller scope:

--- a/docs/AuthorizationPlugin.md
+++ b/docs/AuthorizationPlugin.md
@@ -1,6 +1,6 @@
 ### Authorization plugin support
 
-Support for [Authorization](https://github.com/cakephp/authorization) usage.
+Support for [Authorization plugin](https://github.com/cakephp/authorization) usage.
 
 Instead of the Auth component you load the Authorization one:
 
@@ -9,3 +9,7 @@ $this->loadComponent('TinyAuth.Authorization', [
     ...
 ]);
 ```
+
+For all the rest just follow the plugin's documentation.
+
+Then you use the [Authorization documention](Authorization.md) to fill your config file.

--- a/docs/AuthorizationPlugin.md
+++ b/docs/AuthorizationPlugin.md
@@ -1,0 +1,11 @@
+### Authorization plugin support
+
+Support for [Authorization](https://github.com/cakephp/authorization) usage.
+
+Instead of the Auth component you load the Authorization one:
+
+```php
+$this->loadComponent('TinyAuth.Authorization', [
+    ...
+]);
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,15 @@ By default it will now deny all logged in users any access to any protected acti
 Make sure that the session contains the correct data structure, also make sure the roles are configured or in the database and can be found as expected. The user with the right role should get access now to the corresponding action (make also sure cache is cleared).
 You then verified: authorization is working fine, as well - only with the correct role a user can now access protected actions.
 
+## Working with new plugins
+If you are using [Authentication](https://github.com/cakephp/authentication) or [Authorization](https://github.com/cakephp/authorization) plugin, you will need to use the
+Authentication/Authorization components of this plugin instead for them to work with TinyAuth.
+
+See the docs for details:
+- [TinyAuth and Authentication plugin](AuthenticationPlugin.md)
+- [TinyAuth and Authorization plugin](AuthorizationPlugin.md)
+
+
 ## Contributing
 Feel free to fork and pull request.
 

--- a/src/Auth/AclTrait.php
+++ b/src/Auth/AclTrait.php
@@ -61,8 +61,8 @@ trait AclTrait {
 			'allowUser' => false, // enable to allow ALL roles access to all actions except prefixed with 'adminPrefix'
 			'adminPrefix' => 'admin', // name of the admin prefix route (only used when allowUser is enabled)
 			'cache' => '_cake_core_',
-			'aclCacheKey' => 'tiny_auth_acl',
-			'allowCacheKey' => 'tiny_auth_allow', // This is needed to fetch allow info from the correct cache. Must be the same as set in AuthComponent.
+			'aclCacheKey' => 'tinyauth_acl',
+			'allowCacheKey' => 'tinyauth_allow', // This is needed to fetch allow info from the correct cache. Must be the same as set in AuthComponent.
 			'autoClearCache' => null, // Set to true to delete cache automatically in debug mode, keep null for auto-detect
 			'aclFilePath' => null, // Possible to locate INI file at given path e.g. Plugin::configPath('Admin'), filePath is also available for shared config
 			'aclFile' => 'tinyauth_acl.ini',

--- a/src/Auth/AllowAdapter/AllowAdapterInterface.php
+++ b/src/Auth/AllowAdapter/AllowAdapterInterface.php
@@ -7,11 +7,10 @@ interface AllowAdapterInterface {
 	/**
 	 * Generates and returns a TinyAuth authentication allow/deny list.
 	 *
-	 * @param array $availableRoles A list of available user roles.
 	 * @param array $config Current TinyAuth configuration values.
 	 *
 	 * @return array
 	 */
-	public function getAllow(array $availableRoles, array $config);
+	public function getAllow(array $config);
 
 }

--- a/src/Auth/AllowAdapter/IniAllowAdapter.php
+++ b/src/Auth/AllowAdapter/IniAllowAdapter.php
@@ -11,7 +11,7 @@ class IniAllowAdapter implements AllowAdapterInterface {
 	 *
 	 * @return array
 	 */
-	public function getAllow(array $availableRoles, array $config) {
+	public function getAllow(array $config) {
 		$iniArray = Utility::parseFiles($config['filePath'], $config['file']);
 
 		$auth = [];

--- a/src/Auth/AllowTrait.php
+++ b/src/Auth/AllowTrait.php
@@ -1,0 +1,74 @@
+<?php
+namespace TinyAuth\Auth;
+
+use Cake\Core\Configure;
+use Cake\Core\Exception\Exception;
+use InvalidArgumentException;
+use TinyAuth\Auth\AclAdapter\IniAclAdapter;
+use TinyAuth\Auth\AllowAdapter\AllowAdapterInterface;
+
+trait AllowTrait {
+
+	/**
+	 * @var \TinyAuth\Auth\AllowAdapter\AllowAdapterInterface|null
+	 */
+	protected $_allowAdapter;
+
+	/**
+	 * @return array
+	 */
+	protected function _defaultConfig() {
+		$defaults = [
+			'aclAdapter' => IniAclAdapter::class,
+			'idColumn' => 'id', // ID Column in users table
+			'roleColumn' => 'role_id', // Foreign key for the Role ID in users table or in pivot table
+			'userColumn' => 'user_id', // Foreign key for the User id in pivot table. Only for multi-roles setup
+			'aliasColumn' => 'alias', // Name of column in roles table holding role alias/slug
+			'rolesTable' => 'Roles', // name of Configure key holding available roles OR class name of roles table
+			'usersTable' => 'Users', // name of the Users table
+			'pivotTable' => null, // Should be used in multi-roles setups
+			'multiRole' => false, // true to enables multirole/HABTM authorization (requires a valid pivot table)
+			'superAdminRole' => null, // id of super admin role, which grants access to ALL resources
+			'superAdmin' => null, // super admin, which grants access to ALL resources
+			'superAdminColumn' => null, // Column of super admin
+			'authorizeByPrefix' => false,
+			'prefixes' => [], // Whitelisted prefixes (only used when allowAdmin is enabled), leave empty to use all available
+			'allowUser' => false, // enable to allow ALL roles access to all actions except prefixed with 'adminPrefix'
+			'adminPrefix' => 'admin', // name of the admin prefix route (only used when allowUser is enabled)
+			'cache' => '_cake_core_',
+			'aclCacheKey' => 'tiny_auth_acl',
+			'allowCacheKey' => 'tiny_auth_allow', // This is needed to fetch allow info from the correct cache. Must be the same as set in AuthComponent.
+			'autoClearCache' => null, // Set to true to delete cache automatically in debug mode, keep null for auto-detect
+			'aclFilePath' => null, // Possible to locate INI file at given path e.g. Plugin::configPath('Admin'), filePath is also available for shared config
+			'aclFile' => 'tinyauth_acl.ini',
+			'includeAuthentication' => false, // Set to true to include public auth access into hasAccess() checks. Note, that this requires Configure configuration.
+		];
+		$config = (array)Configure::read('TinyAuth') + $defaults;
+
+		return $config;
+	}
+
+	/**
+	 * Finds the authentication adapter to use for this request.
+	 *
+	 * @param string $adapter Acl adapter to load.
+	 * @return \TinyAuth\Auth\AllowAdapter\AllowAdapterInterface
+	 * @throws \Cake\Core\Exception\Exception
+	 * @throws \InvalidArgumentException
+	 */
+	protected function _loadAllowAdapter($adapter) {
+		if (!class_exists($adapter)) {
+			throw new Exception(sprintf('The Acl Adapter class "%s" was not found.', $adapter));
+		}
+
+		$adapterInstance = new $adapter();
+		if (!($adapterInstance instanceof AllowAdapterInterface)) {
+			throw new InvalidArgumentException(sprintf(
+				'TinyAuth Acl adapters have to implement %s.', AllowAdapterInterface::class
+			));
+		}
+
+		return $adapterInstance;
+	}
+
+}

--- a/src/Auth/AllowTrait.php
+++ b/src/Auth/AllowTrait.php
@@ -15,6 +15,30 @@ trait AllowTrait {
 	protected $_allowAdapter;
 
 	/**
+	 * @param array $params
+	 * @return array
+	 */
+	protected function _getAllowRule(array $params) {
+		$rules = $this->_getAllow($this->getConfig('allowFilePath'));
+
+		foreach ($rules as $rule) {
+			if ($params['plugin'] && $params['plugin'] !== $rule['plugin']) {
+				continue;
+			}
+			if (!empty($params['prefix']) && $params['prefix'] !== $rule['prefix']) {
+				continue;
+			}
+			if ($params['controller'] !== $rule['controller']) {
+				continue;
+			}
+
+			return $rule;
+		}
+
+		return [];
+	}
+
+	/**
 	 * @param string|null $path
 	 * @return array
 	 */

--- a/src/Auth/AllowTrait.php
+++ b/src/Auth/AllowTrait.php
@@ -1,10 +1,10 @@
 <?php
 namespace TinyAuth\Auth;
 
+use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Core\Exception\Exception;
 use InvalidArgumentException;
-use TinyAuth\Auth\AclAdapter\IniAclAdapter;
 use TinyAuth\Auth\AllowAdapter\AllowAdapterInterface;
 
 trait AllowTrait {
@@ -15,37 +15,32 @@ trait AllowTrait {
 	protected $_allowAdapter;
 
 	/**
+	 * @param string|null $path
 	 * @return array
 	 */
-	protected function _defaultConfig() {
-		$defaults = [
-			'aclAdapter' => IniAclAdapter::class,
-			'idColumn' => 'id', // ID Column in users table
-			'roleColumn' => 'role_id', // Foreign key for the Role ID in users table or in pivot table
-			'userColumn' => 'user_id', // Foreign key for the User id in pivot table. Only for multi-roles setup
-			'aliasColumn' => 'alias', // Name of column in roles table holding role alias/slug
-			'rolesTable' => 'Roles', // name of Configure key holding available roles OR class name of roles table
-			'usersTable' => 'Users', // name of the Users table
-			'pivotTable' => null, // Should be used in multi-roles setups
-			'multiRole' => false, // true to enables multirole/HABTM authorization (requires a valid pivot table)
-			'superAdminRole' => null, // id of super admin role, which grants access to ALL resources
-			'superAdmin' => null, // super admin, which grants access to ALL resources
-			'superAdminColumn' => null, // Column of super admin
-			'authorizeByPrefix' => false,
-			'prefixes' => [], // Whitelisted prefixes (only used when allowAdmin is enabled), leave empty to use all available
-			'allowUser' => false, // enable to allow ALL roles access to all actions except prefixed with 'adminPrefix'
-			'adminPrefix' => 'admin', // name of the admin prefix route (only used when allowUser is enabled)
-			'cache' => '_cake_core_',
-			'aclCacheKey' => 'tiny_auth_acl',
-			'allowCacheKey' => 'tiny_auth_allow', // This is needed to fetch allow info from the correct cache. Must be the same as set in AuthComponent.
-			'autoClearCache' => null, // Set to true to delete cache automatically in debug mode, keep null for auto-detect
-			'aclFilePath' => null, // Possible to locate INI file at given path e.g. Plugin::configPath('Admin'), filePath is also available for shared config
-			'aclFile' => 'tinyauth_acl.ini',
-			'includeAuthentication' => false, // Set to true to include public auth access into hasAccess() checks. Note, that this requires Configure configuration.
-		];
-		$config = (array)Configure::read('TinyAuth') + $defaults;
+	protected function _getAllow($path = null) {
+		if ($this->getConfig('autoClearCache') && Configure::read('debug')) {
+			Cache::delete($this->getConfig('allowCacheKey'), $this->getConfig('cache'));
+		}
+		$auth = Cache::read($this->getConfig('allowCacheKey'), $this->getConfig('cache'));
+		if ($auth !== false) {
+			return $auth;
+		}
 
-		return $config;
+		if ($path === null) {
+			$path = $this->getConfig('allowFilePath');
+		}
+
+		$config = $this->getConfig();
+		$config['filePath'] = $path;
+		$config['file'] = $config['allowFile'];
+		unset($config['allowFilePath']);
+		unset($config['allowFile']);
+
+		$auth = $this->_loadAllowAdapter($config['allowAdapter'])->getAllow($config);
+
+		Cache::write($this->getConfig('allowCacheKey'), $auth, $this->getConfig('cache'));
+		return $auth;
 	}
 
 	/**

--- a/src/Command/TinyAuthSyncCommand.php
+++ b/src/Command/TinyAuthSyncCommand.php
@@ -38,7 +38,7 @@ class TinyAuthSyncCommand extends Command implements CommandCollectionAwareInter
 	 * @return int
 	 */
 	public function execute(Arguments $args, ConsoleIo $io) {
-		$syncer = $this->getSyncer();
+		$syncer = $this->_getSyncer();
 		$syncer->syncAcl($args, $io);
 		$io->out('Controllers and ACL synced.');
 
@@ -48,7 +48,7 @@ class TinyAuthSyncCommand extends Command implements CommandCollectionAwareInter
 	/**
 	 * @return \TinyAuth\Sync\Syncer
 	 */
-	protected function getSyncer() {
+	protected function _getSyncer() {
 		return new Syncer();
 	}
 

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -12,6 +12,7 @@ use InvalidArgumentException;
 use TinyAuth\Auth\AclTrait;
 use TinyAuth\Auth\AllowAdapter\AllowAdapterInterface;
 use TinyAuth\Auth\AllowAdapter\IniAllowAdapter;
+use TinyAuth\Auth\AllowTrait;
 
 /**
  * TinyAuth AuthComponent to handle all authentication in a central ini file.
@@ -22,6 +23,7 @@ use TinyAuth\Auth\AllowAdapter\IniAllowAdapter;
 class AuthComponent extends CakeAuthComponent {
 
 	use AclTrait;
+	use AllowTrait;
 
 	/**
 	 * @var array
@@ -93,10 +95,10 @@ class AuthComponent extends CakeAuthComponent {
 	 * @return void
 	 */
 	protected function _prepareAuthentication() {
-		$authentication = $this->_getAuth($this->getConfig('allowFilePath'));
+		$rules = $this->_getAllow($this->getConfig('allowFilePath'));
 
 		$params = $this->request->getAttribute('params');
-		foreach ($authentication as $rule) {
+		foreach ($rules as $rule) {
 			if ($params['plugin'] && $params['plugin'] !== $rule['plugin']) {
 				continue;
 			}
@@ -147,7 +149,7 @@ class AuthComponent extends CakeAuthComponent {
 		unset($config['allowFilePath']);
 		unset($config['allowFile']);
 
-		$auth = $this->_loadAllowAdapter($config['allowAdapter'])->getAllow($this->_getAvailableRoles(), $config);
+		$auth = $this->_loadAllowAdapter($config['allowAdapter'])->getAllow($config);
 
 		Cache::write($this->getConfig('allowCacheKey'), $auth, $this->getConfig('cache'));
 		return $auth;

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -32,7 +32,7 @@ class AuthComponent extends CakeAuthComponent {
 		'allowAdapter' => IniAllowAdapter::class,
 		'cache' => '_cake_core_',
 		'autoClearCache' => null, // Set to true to delete cache automatically in debug mode, keep null for auto-detect
-		'allowCacheKey' => 'tiny_auth_allow',
+		'allowCacheKey' => 'tinyauth_allow',
 		'allowFilePath' => null, // Possible to locate ini file at given path e.g. Plugin::configPath('Admin'), filePath is also available for shared config
 		'allowFile' => 'tinyauth_allow.ini',
 	];
@@ -45,17 +45,6 @@ class AuthComponent extends CakeAuthComponent {
 		$config += $this->_defaultTinyAuthConfig;
 
 		parent::__construct($registry, $config);
-
-		// BC config check
-		if ($this->getConfig('cacheKey')) {
-			$this->setConfig('allowCacheKey', $this->getConfig('cacheKey'));
-		}
-		if ($this->getConfig('file')) {
-			$this->setConfig('allowFile', $this->getConfig('file'));
-		}
-		if ($this->getConfig('filePath')) {
-			$this->setConfig('allowFilePath', $this->getConfig('filePath'));
-		}
 	}
 
 	/**

--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -3,6 +3,7 @@
 namespace TinyAuth\Controller\Component;
 
 use Authentication\Controller\Component\AuthenticationComponent as CakeAuthenticationComponent;
+use Cake\Controller\ComponentRegistry;
 use TinyAuth\Auth\AllowAdapter\IniAllowAdapter;
 use TinyAuth\Auth\AllowTrait;
 
@@ -24,6 +25,16 @@ class AuthenticationComponent extends CakeAuthenticationComponent {
 		'allowFilePath' => null, // Possible to locate ini file at given path e.g. Plugin::configPath('Admin'), filePath is also available for shared config
 		'allowFile' => 'tinyauth_allow.ini',
 	];
+
+	/**
+	 * @param \Cake\Controller\ComponentRegistry $registry
+	 * @param array $config
+	 */
+	public function __construct(ComponentRegistry $registry, array $config = []) {
+		$config += $this->_defaultTinyAuthConfig;
+
+		parent::__construct($registry, $config);
+	}
 
 	/**
 	 * {inheritDoc}

--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -21,7 +21,7 @@ class AuthenticationComponent extends CakeAuthenticationComponent {
 		'allowAdapter' => IniAllowAdapter::class,
 		'cache' => '_cake_core_',
 		'autoClearCache' => null, // Set to true to delete cache automatically in debug mode, keep null for auto-detect
-		'allowCacheKey' => 'tiny_auth_allow',
+		'allowCacheKey' => 'tinyauth_allow',
 		'allowFilePath' => null, // Possible to locate ini file at given path e.g. Plugin::configPath('Admin'), filePath is also available for shared config
 		'allowFile' => 'tinyauth_allow.ini',
 	];

--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -51,7 +51,7 @@ class AuthenticationComponent extends CakeAuthenticationComponent {
 	 * @return void
 	 */
 	protected function _prepareAuthentication() {
-		$rule = $this->_getRule($this->_registry->getController()->getRequest()->getAttribute('params'));
+		$rule = $this->_getAllowRule($this->_registry->getController()->getRequest()->getAttribute('params'));
 		if (!$rule) {
 			return;
 		}
@@ -60,11 +60,11 @@ class AuthenticationComponent extends CakeAuthenticationComponent {
 			return;
 		}
 
-		$allowed = [];
+		$allowed = $this->unauthenticatedActions;
 		if (in_array('*', $rule['allow'], true)) {
 			$allowed = $this->_getAllActions();
 		} elseif (!empty($rule['allow'])) {
-			$allowed = $rule['allow'];
+			$allowed = array_merge($allowed, $rule['allow']);
 		}
 		if (!empty($rule['deny'])) {
 			$allowed = array_diff($allowed, $rule['deny']);
@@ -74,37 +74,7 @@ class AuthenticationComponent extends CakeAuthenticationComponent {
 			return;
 		}
 
-		/*
-		if ($allowAll) {
-			$this->setConfig('requireIdentity', false);
-			return;
-		}
-		*/
-
 		$this->allowUnauthenticated($allowed);
-	}
-
-	/**
-	 * @param array $params
-	 * @return array
-	 */
-	protected function _getRule(array $params) {
-		$rules = $this->_getAllow($this->getConfig('allowFilePath'));
-		foreach ($rules as $rule) {
-			if ($params['plugin'] && $params['plugin'] !== $rule['plugin']) {
-				continue;
-			}
-			if (!empty($params['prefix']) && $params['prefix'] !== $rule['prefix']) {
-				continue;
-			}
-			if ($params['controller'] !== $rule['controller']) {
-				continue;
-			}
-
-			return $rule;
-		}
-
-		return [];
 	}
 
 	/**

--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -41,8 +41,7 @@ class AuthenticationComponent extends CakeAuthenticationComponent {
 	 *
 	 * @return void
 	 */
-	public function startup()
-	{
+	public function startup() {
 		$this->_prepareAuthentication();
 
 		parent::startup();
@@ -51,8 +50,7 @@ class AuthenticationComponent extends CakeAuthenticationComponent {
 	/**
 	 * @return void
 	 */
-	protected function _prepareAuthentication()
-	{
+	protected function _prepareAuthentication() {
 		$rule = $this->_getRule($this->_registry->getController()->getRequest()->getAttribute('params'));
 		if (!$rule) {
 			return;
@@ -76,10 +74,12 @@ class AuthenticationComponent extends CakeAuthenticationComponent {
 			return;
 		}
 
-		if (false) {
+		/*
+		if ($allowAll) {
 			$this->setConfig('requireIdentity', false);
 			return;
 		}
+		*/
 
 		$this->allowUnauthenticated($allowed);
 	}
@@ -88,8 +88,7 @@ class AuthenticationComponent extends CakeAuthenticationComponent {
 	 * @param array $params
 	 * @return array
 	 */
-	protected function _getRule(array $params)
-	{
+	protected function _getRule(array $params) {
 		$rules = $this->_getAllow($this->getConfig('allowFilePath'));
 		foreach ($rules as $rule) {
 			if ($params['plugin'] && $params['plugin'] !== $rule['plugin']) {
@@ -111,12 +110,10 @@ class AuthenticationComponent extends CakeAuthenticationComponent {
 	/**
 	 * @return array
 	 */
-	protected function _getAllActions()
-	{
+	protected function _getAllActions() {
 		$controller = $this->_registry->getController();
 
 		return get_class_methods($controller);
 	}
-
 
 }

--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace TinyAuth\Controller\Component;
+
+use Authentication\Controller\Component\AuthenticationComponent as CakeAuthenticationComponent;
+use TinyAuth\Auth\AllowAdapter\IniAllowAdapter;
+use TinyAuth\Auth\AllowTrait;
+
+/**
+ * TinyAuth AuthenticationComponent to handle all authentication in a central ini file.
+ */
+class AuthenticationComponent extends CakeAuthenticationComponent {
+
+	use AllowTrait;
+
+	/**
+	 * @var array
+	 */
+	protected $_defaultTinyAuthConfig = [
+		'allowAdapter' => IniAllowAdapter::class,
+		'cache' => '_cake_core_',
+		'autoClearCache' => null, // Set to true to delete cache automatically in debug mode, keep null for auto-detect
+		'allowCacheKey' => 'tiny_auth_allow',
+		'allowFilePath' => null, // Possible to locate ini file at given path e.g. Plugin::configPath('Admin'), filePath is also available for shared config
+		'allowFile' => 'tinyauth_allow.ini',
+	];
+
+}

--- a/src/Controller/Component/AuthorizationComponent.php
+++ b/src/Controller/Component/AuthorizationComponent.php
@@ -22,7 +22,7 @@ class AuthorizationComponent extends CakeAuthorizationComponent {
 		'allowAdapter' => IniAllowAdapter::class,
 		'cache' => '_cake_core_',
 		'autoClearCache' => null, // Set to true to delete cache automatically in debug mode, keep null for auto-detect
-		'allowCacheKey' => 'tiny_auth_allow',
+		'allowCacheKey' => 'tinyauth_allow',
 		'allowFilePath' => null, // Possible to locate ini file at given path e.g. Plugin::configPath('Admin'), filePath is also available for shared config
 		'allowFile' => 'tinyauth_allow.ini',
 	];

--- a/src/Controller/Component/AuthorizationComponent.php
+++ b/src/Controller/Component/AuthorizationComponent.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace TinyAuth\Controller\Component;
+
+use Authorization\Controller\Component\AuthorizationComponent as CakeAuthorizationComponent;
+use TinyAuth\Auth\AclTrait;
+use TinyAuth\Auth\AllowAdapter\IniAllowAdapter;
+
+/**
+ * TinyAuth AuthorizationComponent to handle all authorization in a central ini file.
+ */
+class AuthorizationComponent extends CakeAuthorizationComponent {
+
+	use AclTrait;
+
+	/**
+	 * @var array
+	 */
+	protected $_defaultTinyAuthConfig = [
+		'allowAdapter' => IniAllowAdapter::class,
+		'cache' => '_cake_core_',
+		'autoClearCache' => null, // Set to true to delete cache automatically in debug mode, keep null for auto-detect
+		'allowCacheKey' => 'tiny_auth_allow',
+		'allowFilePath' => null, // Possible to locate ini file at given path e.g. Plugin::configPath('Admin'), filePath is also available for shared config
+		'allowFile' => 'tinyauth_allow.ini',
+	];
+
+}

--- a/src/Controller/Component/AuthorizationComponent.php
+++ b/src/Controller/Component/AuthorizationComponent.php
@@ -3,6 +3,8 @@
 namespace TinyAuth\Controller\Component;
 
 use Authorization\Controller\Component\AuthorizationComponent as CakeAuthorizationComponent;
+use Cake\Controller\ComponentRegistry;
+use Cake\Event\Event;
 use TinyAuth\Auth\AclTrait;
 use TinyAuth\Auth\AllowAdapter\IniAllowAdapter;
 
@@ -24,5 +26,37 @@ class AuthorizationComponent extends CakeAuthorizationComponent {
 		'allowFilePath' => null, // Possible to locate ini file at given path e.g. Plugin::configPath('Admin'), filePath is also available for shared config
 		'allowFile' => 'tinyauth_allow.ini',
 	];
+
+	/**
+	 * @param \Cake\Controller\ComponentRegistry $registry
+	 * @param array $config
+	 */
+	public function __construct(ComponentRegistry $registry, array $config = []) {
+		$config += ($this->_defaultTinyAuthConfig + $this->_defaultConfig());
+
+		parent::__construct($registry, $config);
+	}
+
+	/**
+	 * Callback for Controller.startup event.
+	 *
+	 * @param \Cake\Event\Event $event Event instance.
+	 * @return \Cake\Http\Response|null
+	 */
+	public function startup(Event $event) {
+		$this->_prepareAuthorization($event);
+
+		return null;
+	}
+
+	/**
+	 * @param \Cake\Event\Event $event
+	 * @return void
+	 */
+	protected function _prepareAuthorization(Event $event) {
+		//TODO 'skipAuthorization' from allow ini config
+		//TODO 'authorizeModel' and maybe 'actionMap'
+		//TODO rest
+	}
 
 }

--- a/src/Sync/Syncer.php
+++ b/src/Sync/Syncer.php
@@ -31,7 +31,7 @@ class Syncer {
 		$file = ROOT . DS . 'config' . DS . $config['file'];
 		$content = Utility::parseFile($file);
 
-		$controllers = $this->getControllers((string)$args->getOption('plugin'));
+		$controllers = $this->_getControllers((string)$args->getOption('plugin'));
 		foreach ($controllers as $controller) {
 			if (isset($content[$controller])) {
 				continue;
@@ -60,13 +60,13 @@ class Syncer {
 	 * @param string $plugin
 	 * @return array
 	 */
-	protected function getControllers($plugin) {
+	protected function _getControllers($plugin) {
 		if ($plugin === 'all') {
 			$plugins = (array)Plugin::loaded();
 
 			$controllers = [];
 			foreach ($plugins as $plugin) {
-				$controllers = array_merge($controllers, $this->getControllers($plugin));
+				$controllers = array_merge($controllers, $this->_getControllers($plugin));
 			}
 
 			return $controllers;
@@ -76,7 +76,7 @@ class Syncer {
 
 		$controllers = [];
 		foreach ($folders as $folder) {
-			$controllers = array_merge($controllers, $this->parseControllers($folder, $plugin));
+			$controllers = array_merge($controllers, $this->_parseControllers($folder, $plugin));
 		}
 
 		return $controllers;
@@ -89,7 +89,7 @@ class Syncer {
 	 *
 	 * @return array
 	 */
-	protected function parseControllers($folder, $plugin, $prefix = null) {
+	protected function _parseControllers($folder, $plugin, $prefix = null) {
 		$folderContent = (new Folder($folder))->read(Folder::SORT_NAME, true);
 
 		$controllers = [];
@@ -104,7 +104,7 @@ class Syncer {
 				continue;
 			}
 
-			if ($this->noAuthenticationNeeded($name, $plugin, $prefix)) {
+			if ($this->_noAuthenticationNeeded($name, $plugin, $prefix)) {
 				continue;
 			}
 
@@ -118,7 +118,7 @@ class Syncer {
 				continue;
 			}
 
-			$controllers = array_merge($controllers, $this->parseControllers($folder . $subFolder . DS, $plugin, $subFolder));
+			$controllers = array_merge($controllers, $this->_parseControllers($folder . $subFolder . DS, $plugin, $subFolder));
 		}
 
 		return $controllers;
@@ -130,9 +130,9 @@ class Syncer {
 	 * @param string $prefix
 	 * @return bool
 	 */
-	protected function noAuthenticationNeeded($name, $plugin, $prefix) {
+	protected function _noAuthenticationNeeded($name, $plugin, $prefix) {
 		if (!isset($this->authAllow)) {
-			$this->authAllow = $this->parseAuthAllow();
+			$this->authAllow = $this->_parseAuthAllow();
 		}
 
 		$key = $name;
@@ -151,7 +151,7 @@ class Syncer {
 	/**
 	 * @return array
 	 */
-	protected function parseAuthAllow() {
+	protected function _parseAuthAllow() {
 		$defaults = [
 			'file' => 'tinyauth_allow.ini',
 		];

--- a/src/Sync/Syncer.php
+++ b/src/Sync/Syncer.php
@@ -24,7 +24,7 @@ class Syncer {
 	 */
 	public function syncAcl(Arguments $args, ConsoleIo $io) {
 		$defaults = [
-			'file' => 'acl.ini',
+			'file' => 'tinyauth_acl.ini',
 		];
 		$config = (array)Configure::read('TinyAuth') + $defaults;
 
@@ -153,7 +153,7 @@ class Syncer {
 	 */
 	protected function parseAuthAllow() {
 		$defaults = [
-			'file' => 'auth_allow.ini',
+			'file' => 'tinyauth_allow.ini',
 		];
 		$config = (array)Configure::read('TinyAuth') + $defaults;
 

--- a/tests/TestCase/Controller/Component/AuthUserComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthUserComponentTest.php
@@ -112,7 +112,7 @@ class AuthUserComponentTest extends TestCase {
 	public function testHasAccessPublic() {
 		$this->AuthUser->setConfig('includeAuthentication', true);
 		$cache = '_cake_core_';
-		$cacheKey = 'tiny_auth_allow';
+		$cacheKey = 'tinyauth_allow';
 		$this->AuthUser->setConfig('cache', $cache);
 		$this->AuthUser->setConfig('cacheKey', $cacheKey);
 
@@ -138,7 +138,7 @@ class AuthUserComponentTest extends TestCase {
 	public function testHasAccessPublicInvalid() {
 		$this->AuthUser->setConfig('includeAuthentication', true);
 		$cache = '_cake_core_';
-		$cacheKey = 'tiny_auth_allow';
+		$cacheKey = 'tinyauth_allow';
 		$this->AuthUser->setConfig('cache', $cache);
 		$this->AuthUser->setConfig('cacheKey', $cacheKey);
 

--- a/tests/TestCase/View/Helper/AuthUserHelperTest.php
+++ b/tests/TestCase/View/Helper/AuthUserHelperTest.php
@@ -245,7 +245,7 @@ class AuthUserHelperTest extends TestCase {
 	public function testHasAccessPublic() {
 		$this->AuthUserHelper->setConfig('includeAuthentication', true);
 		$cache = '_cake_core_';
-		$cacheKey = 'tiny_auth_allow';
+		$cacheKey = 'tinyauth_allow';
 		$this->AuthUserHelper->setConfig('cache', $cache);
 		$this->AuthUserHelper->setConfig('cacheKey', $cacheKey);
 


### PR DESCRIPTION
Start implementing https://github.com/dereuromark/cakephp-tinyauth/issues/84
to have support for [Authentication](https://github.com/cakephp/authentication) and/or [Authorization](https://github.com/cakephp/authorization) plugins

This will go into new 2.0 major release.

Things to do before:

- implement policy for middleware usage
- implement component and helpers for new plugin way

Possible idea for AclPolicy:
```php
public function canAccess($identity, $resource)
    {
        $rbac = $this->getRbac($resource); // TinyAuth rbac

        $user = $identity ? $identity->getOriginalData()->toArray() : [];

        return (bool)$rbac->checkPermissions($user, $resource);
    }
```