### PR TITLE
 Identity data type check.

### DIFF
--- a/src/Policy/RequestPolicy.php
+++ b/src/Policy/RequestPolicy.php
@@ -2,6 +2,7 @@
 
 namespace TinyAuth\Policy;
 
+use ArrayAccess;
 use Authorization\IdentityInterface;
 use Authorization\Policy\RequestPolicyInterface;
 use Cake\Core\InstanceConfigTrait;
@@ -41,9 +42,14 @@ class RequestPolicy implements RequestPolicyInterface {
 	 * @param \Cake\Http\ServerRequest $request Request
 	 * @return bool
 	 */
-	public function canAccess(?IdentityInterface $identity, ServerRequest $request) {
+	public function canAccess(?IdentityInterface $identity, ServerRequest $request): bool
+	{
 		$params = $request->getAttribute('params');
-		$user = $identity ? (array)$identity->getOriginalData() : [];
+		$user = [];
+		if ($identity) {
+			$data = $identity->getOriginalData();
+			$user = ($data instanceof ArrayAccess) ? $data->toArray() : (array)$data;
+		}
 
 		return $this->_checkUser($user, $params);
 	}

--- a/src/Policy/RequestPolicy.php
+++ b/src/Policy/RequestPolicy.php
@@ -42,8 +42,7 @@ class RequestPolicy implements RequestPolicyInterface {
 	 * @param \Cake\Http\ServerRequest $request Request
 	 * @return bool
 	 */
-	public function canAccess(?IdentityInterface $identity, ServerRequest $request): bool
-	{
+	public function canAccess(?IdentityInterface $identity, ServerRequest $request): bool {
 		$params = $request->getAttribute('params');
 		$user = [];
 		if ($identity) {


### PR DESCRIPTION
Hello @dereuromark.

I faced the same issue #116.

Use:
1. cakephp/cakephp 4.1.4
2. cakephp/authentication 2.3.0
3. dereuromark/cakephp-tinyauth 3.0.1

Regarding storage of an object in a session, I contacted the forum https://discourse.cakephp.org/t/cakephp-4-plugin-authentication-an-array-in-session-not-an-object/8397

Based on your suggestion from #116, created a PR.