### PR TITLE
Fix access to private fields in user array

### DIFF
--- a/src/Auth/AclTrait.php
+++ b/src/Auth/AclTrait.php
@@ -94,6 +94,10 @@ trait AclTrait {
 			return false;
 		}
 
+		if (isset($user["\0*\0_fields"])) {
+			$user=$user["\0*\0_fields"];
+		}
+	  	
 		if ($this->getConfig('superAdmin')) {
 			$superAdminColumn = $this->getConfig('superAdminColumn');
 			if (!$superAdminColumn) {


### PR DESCRIPTION
This fixes (see issue #121) AclTrait when accessing user data produced by `(array) Identity->getOriginalData()` conversion.