### PR TITLE
5.x: fix broken AuthUserHelperTests

### DIFF
--- a/tests/TestCase/View/Helper/AuthUserHelperTest.php
+++ b/tests/TestCase/View/Helper/AuthUserHelperTest.php
@@ -85,7 +85,6 @@ class AuthUserHelperTest extends TestCase {
 		$this->assertTrue($result);
 
 		$builder = Router::createRouteBuilder('/');
-		$builder->setRouteClass(DashedRoute::class);
 		$builder->connect(
 			'/edit/*',
 			['controller' => 'Tags', 'action' => 'edit'],
@@ -221,7 +220,6 @@ class AuthUserHelperTest extends TestCase {
 		$this->View->set('_authUser', $user);
 
 		$builder = Router::createRouteBuilder('/');
-		$builder->setRouteClass(DashedRoute::class);
 		$builder->connect(
 			'/view/{id}',
 			['controller' => 'Posts', 'action' => 'view'],


### PR DESCRIPTION
Refs: https://github.com/cakephp/cakephp/issues/17265

previously the DashedRoute was only used for fallback routes, not for all configured routes in the builder.