### PR TITLE
Use only id for Session storage.

### DIFF
--- a/src/Authenticator/SessionAuthenticator.php
+++ b/src/Authenticator/SessionAuthenticator.php
@@ -1,0 +1,173 @@
+<?php
+declare(strict_types=1);
+
+namespace TinyAuth\Authenticator;
+
+use ArrayAccess;
+use ArrayObject;
+use Authentication\Authenticator\Result;
+use Authentication\Authenticator\ResultInterface;
+use Authentication\Authenticator\SessionAuthenticator as AuthenticationSessionAuthenticator;
+use Authentication\Identifier\IdentifierInterface;
+use Cake\Datasource\EntityInterface;
+use Cake\Http\Exception\UnauthorizedException;
+use Cake\ORM\TableRegistry;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Session Authenticator with only ID
+ */
+class SessionAuthenticator extends AuthenticationSessionAuthenticator {
+
+	/**
+	 * @param \Authentication\Identifier\IdentifierInterface $identifier
+	 * @param array<string, mixed> $config
+	 */
+	public function __construct(IdentifierInterface $identifier, array $config = []) {
+		$config += [
+			'modelClass' => 'Users',
+		];
+
+		parent::__construct($identifier, $config);
+	}
+
+	/**
+	 * Authenticate a user using session data.
+	 *
+	 * @param \Psr\Http\Message\ServerRequestInterface $request The request to authenticate with.
+	 * @return \Authentication\Authenticator\ResultInterface
+	 */
+	public function authenticate(ServerRequestInterface $request): ResultInterface {
+		$sessionKey = $this->getConfig('sessionKey');
+		/** @var \Cake\Http\Session $session */
+		$session = $request->getAttribute('session');
+		$user = $session->read($sessionKey);
+
+		if (!$user) {
+			return new Result(null, Result::FAILURE_IDENTITY_NOT_FOUND);
+		}
+
+		if ($this->getConfig('identify') === true) {
+			$credentials = [];
+			foreach ($this->getConfig('fields') as $key => $field) {
+				$credentials[$key] = $user[$field];
+			}
+			$user = $this->_identifier->identify($credentials);
+
+			if (!$user) {
+				return new Result(null, Result::FAILURE_CREDENTIALS_INVALID);
+			}
+		} else {
+			$user = $this->hydrateFromSession($user);
+		}
+
+		if (!($user instanceof ArrayAccess)) {
+			$user = new ArrayObject($user);
+		}
+
+		return new Result($user, Result::SUCCESS);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function persistIdentity(ServerRequestInterface $request, ResponseInterface $response, $identity): array {
+		$sessionKey = $this->getConfig('sessionKey');
+		/** @var \Cake\Http\Session $session */
+		$session = $request->getAttribute('session');
+
+		if (!$session->check($sessionKey)) {
+			$session->renew();
+			$session->write($sessionKey, $identity['id']);
+		}
+
+		return [
+			'request' => $request,
+			'response' => $response,
+		];
+	}
+
+	/**
+	 * Impersonates a user
+	 *
+	 * @param \Psr\Http\Message\ServerRequestInterface $request The request
+	 * @param \Psr\Http\Message\ResponseInterface $response The response
+	 * @param \ArrayAccess $impersonator User who impersonates
+	 * @param \ArrayAccess $impersonated User impersonated
+	 * @return array
+	 */
+	public function impersonate(
+		ServerRequestInterface $request,
+		ResponseInterface $response,
+		ArrayAccess $impersonator,
+		ArrayAccess $impersonated,
+	): array {
+		$sessionKey = $this->getConfig('sessionKey');
+		$impersonateSessionKey = $this->getConfig('impersonateSessionKey');
+		/** @var \Cake\Http\Session $session */
+		$session = $request->getAttribute('session');
+		if ($session->check($impersonateSessionKey)) {
+			throw new UnauthorizedException(
+				'You are impersonating a user already. ' .
+				'Stop the current impersonation before impersonating another user.',
+			);
+		}
+		$session->write($impersonateSessionKey, $impersonator['id']);
+		$session->write($sessionKey, $impersonated['id']);
+		$this->setConfig('identify', true);
+
+		return [
+			'request' => $request,
+			'response' => $response,
+		];
+	}
+
+	/**
+	 * Stops impersonation
+	 *
+	 * @param \Psr\Http\Message\ServerRequestInterface $request The request
+	 * @param \Psr\Http\Message\ResponseInterface $response The response
+	 * @return array
+	 */
+	public function stopImpersonating(ServerRequestInterface $request, ResponseInterface $response): array {
+		$sessionKey = $this->getConfig('sessionKey');
+		$impersonateSessionKey = $this->getConfig('impersonateSessionKey');
+		/** @var \Cake\Http\Session $session */
+		$session = $request->getAttribute('session');
+		if ($session->check($impersonateSessionKey)) {
+			$id = $session->read($impersonateSessionKey);
+			$session->delete($impersonateSessionKey);
+			$session->write($sessionKey, $id);
+			$this->setConfig('identify', true);
+		}
+
+		return [
+			'request' => $request,
+			'response' => $response,
+		];
+	}
+
+	/**
+	 * Returns true if impersonation is being done
+	 *
+	 * @param \Psr\Http\Message\ServerRequestInterface $request The request
+	 * @return bool
+	 */
+	public function isImpersonating(ServerRequestInterface $request): bool {
+		$impersonateSessionKey = $this->getConfig('impersonateSessionKey');
+		/** @var \Cake\Http\Session $session */
+		$session = $request->getAttribute('session');
+
+		return $session->check($impersonateSessionKey);
+	}
+
+	/**
+	 * @param string|int $user
+	 * @return \Cake\Datasource\EntityInterface
+	 */
+	protected function hydrateFromSession(string|int $user): EntityInterface {
+		return TableRegistry::getTableLocator()->get($this->getConfig('modelClass'))->get($user);
+	}
+
+}

--- a/src/Authenticator/SessionAuthenticator.php
+++ b/src/Authenticator/SessionAuthenticator.php
@@ -107,43 +107,4 @@ class SessionAuthenticator extends AuthenticationSessionAuthenticator {
 		];
 	}
 
-	/**
-	 * Stops impersonation
-	 *
-	 * @param \Psr\Http\Message\ServerRequestInterface $request The request
-	 * @param \Psr\Http\Message\ResponseInterface $response The response
-	 * @return array
-	 */
-	public function stopImpersonating(ServerRequestInterface $request, ResponseInterface $response): array {
-		$sessionKey = $this->getConfig('sessionKey');
-		$impersonateSessionKey = $this->getConfig('impersonateSessionKey');
-		/** @var \Cake\Http\Session $session */
-		$session = $request->getAttribute('session');
-		if ($session->check($impersonateSessionKey)) {
-			$id = $session->read($impersonateSessionKey);
-			$session->delete($impersonateSessionKey);
-			$session->write($sessionKey, $id);
-			$this->setConfig('identify', true);
-		}
-
-		return [
-			'request' => $request,
-			'response' => $response,
-		];
-	}
-
-	/**
-	 * Returns true if impersonation is being done
-	 *
-	 * @param \Psr\Http\Message\ServerRequestInterface $request The request
-	 * @return bool
-	 */
-	public function isImpersonating(ServerRequestInterface $request): bool {
-		$impersonateSessionKey = $this->getConfig('impersonateSessionKey');
-		/** @var \Cake\Http\Session $session */
-		$session = $request->getAttribute('session');
-
-		return $session->check($impersonateSessionKey);
-	}
-
 }

--- a/tests/TestCase/Authenticator/SessionAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/SessionAuthenticatorTest.php
@@ -66,6 +66,17 @@ class SessionAuthenticatorTest extends TestCase {
 
 		$request = $request->withAttribute('session', $this->sessionMock);
 
+		$this->identifiers = new IdentifierCollection([
+			'Authentication.Token' => [
+				'tokenField' => 'id',
+				'dataField' => 'id',
+				'resolver' => [
+					'className' => 'Authentication.Orm',
+					'finder' => 'active',
+				],
+			],
+		]);
+
 		$authenticator = new SessionAuthenticator($this->identifiers);
 		$result = $authenticator->authenticate($request);
 
@@ -95,8 +106,18 @@ class SessionAuthenticatorTest extends TestCase {
 
 		$request = $request->withAttribute('session', $this->sessionMock);
 
+		$this->identifiers = new IdentifierCollection([
+			'Authentication.Token' => [
+				'tokenField' => 'id',
+				'dataField' => 'id',
+				'resolver' => [
+					'className' => 'Authentication.Orm',
+					'finder' => 'active',
+				],
+			],
+		]);
+
 		$authenticator = new SessionAuthenticator($this->identifiers, [
-			'finder' => 'active',
 		]);
 		$result = $authenticator->authenticate($request);
 

--- a/tests/TestCase/Authenticator/SessionAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/SessionAuthenticatorTest.php
@@ -1,0 +1,399 @@
+<?php
+declare(strict_types=1);
+
+namespace TinyAuth\Test\TestCase\Authenticator;
+
+use ArrayObject;
+use Authentication\Authenticator\Result;
+use Authentication\Identifier\IdentifierCollection;
+use Cake\Http\Exception\UnauthorizedException;
+use Cake\Http\Response;
+use Cake\Http\ServerRequestFactory;
+use Cake\Http\Session;
+use Cake\TestSuite\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use TinyAuth\Authenticator\SessionAuthenticator;
+
+class SessionAuthenticatorTest extends TestCase {
+
+	/**
+	 * @var array<string>
+	 */
+	protected array $fixtures = [
+		'plugin.TinyAuth.Users',
+		'plugin.TinyAuth.DatabaseRoles',
+	];
+
+	/**
+	 * @var \Authentication\IdentifierCollection
+	 */
+	protected $identifiers;
+
+	/**
+	 * @var \Cake\Http\Session&\PHPUnit\Framework\MockObject\MockObject
+	 */
+	protected $sessionMock;
+
+	/**
+	 * @inheritDoc
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->identifiers = new IdentifierCollection([
+		   'Authentication.Password',
+		]);
+
+		$this->sessionMock = $this->getMockBuilder(Session::class)
+			->disableOriginalConstructor()
+			->onlyMethods(['read', 'write', 'delete', 'renew', 'check'])
+			->getMock();
+	}
+
+	/**
+	 * Test authentication
+	 *
+	 * @return void
+	 */
+	public function testAuthenticateSuccess() {
+		$request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/']);
+
+		$this->sessionMock->expects($this->once())
+			->method('read')
+			->with('Auth')
+			->willReturn(1);
+
+		$request = $request->withAttribute('session', $this->sessionMock);
+
+		$authenticator = new SessionAuthenticator($this->identifiers);
+		$result = $authenticator->authenticate($request);
+
+		$this->assertInstanceOf(Result::class, $result);
+		$this->assertSame(Result::SUCCESS, $result->getStatus());
+	}
+
+	/**
+	 * Test authentication
+	 *
+	 * @return void
+	 */
+	public function testAuthenticateSuccessCustomFinder() {
+		$request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/']);
+
+		$usersTable = $this->fetchTable('Users');
+		$rolesTable = $this->fetchTable('DatabaseRoles');
+		$role = $rolesTable->find()->firstOrFail();
+		$user = $usersTable->find()->firstOrFail();
+		$user->role_id = $role->id;
+		$usersTable->saveOrFail($user);
+
+		$this->sessionMock->expects($this->once())
+			->method('read')
+			->with('Auth')
+			->willReturn($user->id);
+
+		$request = $request->withAttribute('session', $this->sessionMock);
+
+		$authenticator = new SessionAuthenticator($this->identifiers, [
+			'finder' => 'active',
+		]);
+		$result = $authenticator->authenticate($request);
+
+		$this->assertInstanceOf(Result::class, $result);
+		$this->assertSame(Result::SUCCESS, $result->getStatus());
+
+		$entity = $result->getData();
+		$this->assertNotEmpty($entity->database_role);
+	}
+
+	/**
+	 * Test authentication
+	 *
+	 * @return void
+	 */
+	public function testAuthenticateFailure() {
+		$request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/']);
+
+		$this->sessionMock->expects($this->once())
+			->method('read')
+			->with('Auth')
+			->willReturn(null);
+
+		$request = $request->withAttribute('session', $this->sessionMock);
+
+		$authenticator = new SessionAuthenticator($this->identifiers);
+		$result = $authenticator->authenticate($request);
+
+		$this->assertInstanceOf(Result::class, $result);
+		$this->assertSame(Result::FAILURE_IDENTITY_NOT_FOUND, $result->getStatus());
+	}
+
+	/**
+	 * Test session data verification by database lookup failure
+	 *
+	 * @return void
+	 */
+	public function testVerifyByDatabaseFailure() {
+		$request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/']);
+
+		$this->sessionMock->expects($this->once())
+			->method('read')
+			->with('Auth')
+			->willReturn(999);
+
+		$request = $request->withAttribute('session', $this->sessionMock);
+
+		$authenticator = new SessionAuthenticator($this->identifiers, [
+		]);
+		$result = $authenticator->authenticate($request);
+
+		$this->assertInstanceOf(Result::class, $result);
+		$this->assertSame(Result::FAILURE_IDENTITY_NOT_FOUND, $result->getStatus());
+	}
+
+	/**
+	 * testPersistIdentity
+	 *
+	 * @return void
+	 */
+	public function testPersistIdentity() {
+		$request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/']);
+		$request = $request->withAttribute('session', $this->sessionMock);
+		$response = new Response();
+		$authenticator = new SessionAuthenticator($this->identifiers);
+
+		$data = new ArrayObject(['id' => 1]);
+
+		$this->sessionMock
+			->expects($this->exactly(2))
+			->method('check')
+			->with(
+				...static::withConsecutive(['Auth'], ['Auth']),
+			)
+			->willReturnOnConsecutiveCalls(false, true);
+
+		$this->sessionMock
+			->expects($this->once())
+			->method('renew');
+
+		$this->sessionMock
+			->expects($this->once())
+			->method('write')
+			->with('Auth', 1);
+
+		$result = $authenticator->persistIdentity($request, $response, $data);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('request', $result);
+		$this->assertArrayHasKey('response', $result);
+		$this->assertInstanceOf(RequestInterface::class, $result['request']);
+		$this->assertInstanceOf(ResponseInterface::class, $result['response']);
+
+		// Persist again to make sure identity isn't replaced if it exists.
+		$authenticator->persistIdentity($request, $response, 2);
+	}
+
+	/**
+	 * testClearIdentity
+	 *
+	 * @return void
+	 */
+	public function testClearIdentity() {
+		$request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/']);
+		$request = $request->withAttribute('session', $this->sessionMock);
+		$response = new Response();
+
+		$authenticator = new SessionAuthenticator($this->identifiers);
+
+		$this->sessionMock->expects($this->once())
+			->method('delete')
+			->with('Auth');
+
+		$this->sessionMock
+			->expects($this->once())
+			->method('renew');
+
+		$result = $authenticator->clearIdentity($request, $response);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('request', $result);
+		$this->assertArrayHasKey('response', $result);
+		$this->assertInstanceOf(RequestInterface::class, $result['request']);
+		$this->assertInstanceOf(ResponseInterface::class, $result['response']);
+	}
+
+	/**
+	 * testImpersonate
+	 *
+	 * @return void
+	 */
+	public function testImpersonate() {
+		$request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/']);
+		$request = $request->withAttribute('session', $this->sessionMock);
+		$response = new Response();
+
+		$authenticator = new SessionAuthenticator($this->identifiers);
+		$usersTable = $this->fetchTable('Users');
+		$impersonator = $usersTable->newEntity([
+			'username' => 'mariano',
+			'password' => 'password',
+		]);
+		$impersonator->id = 123;
+		$impersonated = $usersTable->newEntity(['username' => 'larry']);
+		$impersonated->id = 456;
+
+		$this->sessionMock->expects($this->once())
+			->method('check')
+			->with('AuthImpersonate');
+
+		$this->sessionMock
+			->expects($this->exactly(2))
+			->method('write')
+			->with(
+				...static::withConsecutive(['AuthImpersonate', $impersonator->id], ['Auth', $impersonated->id]),
+			);
+
+		$result = $authenticator->impersonate($request, $response, $impersonator, $impersonated);
+
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('request', $result);
+		$this->assertArrayHasKey('response', $result);
+		$this->assertInstanceOf(RequestInterface::class, $result['request']);
+		$this->assertInstanceOf(ResponseInterface::class, $result['response']);
+	}
+
+	/**
+	 * testImpersonateAlreadyImpersonating
+	 *
+	 * @return void
+	 */
+	public function testImpersonateAlreadyImpersonating() {
+		$request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/']);
+		$request = $request->withAttribute('session', $this->sessionMock);
+		$response = new Response();
+
+		$authenticator = new SessionAuthenticator($this->identifiers);
+		$impersonator = new ArrayObject([
+			'username' => 'mariano',
+			'password' => 'password',
+		]);
+		$impersonated = new ArrayObject(['username' => 'larry']);
+
+		$this->sessionMock->expects($this->once())
+			->method('check')
+			->with('AuthImpersonate')
+			->willReturn(true);
+
+		$this->sessionMock
+			->expects($this->never())
+			->method('write');
+
+		$this->expectException(UnauthorizedException::class);
+		$this->expectExceptionMessage(
+			'You are impersonating a user already. Stop the current impersonation before impersonating another user.',
+		);
+		$authenticator->impersonate($request, $response, $impersonator, $impersonated);
+	}
+
+	/**
+	 * testStopImpersonating
+	 *
+	 * @return void
+	 */
+	public function testStopImpersonating() {
+		$request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/']);
+		$request = $request->withAttribute('session', $this->sessionMock);
+		$response = new Response();
+
+		$authenticator = new SessionAuthenticator($this->identifiers);
+
+		$impersonator = new ArrayObject([
+			'username' => 'mariano',
+			'password' => 'password',
+		]);
+
+		$this->sessionMock->expects($this->once())
+			->method('check')
+			->with('AuthImpersonate')
+			->willReturn(true);
+
+		$this->sessionMock
+			->expects($this->once())
+			->method('read')
+			->with('AuthImpersonate')
+			->willReturn($impersonator);
+
+		$this->sessionMock
+			->expects($this->once())
+			->method('delete')
+			->with('AuthImpersonate');
+
+		$this->sessionMock
+			->expects($this->once())
+			->method('write')
+			->with('Auth', $impersonator);
+
+		$result = $authenticator->stopImpersonating($request, $response);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('request', $result);
+		$this->assertArrayHasKey('response', $result);
+		$this->assertInstanceOf(RequestInterface::class, $result['request']);
+		$this->assertInstanceOf(ResponseInterface::class, $result['response']);
+	}
+
+	/**
+	 * testStopImpersonatingNotImpersonating
+	 *
+	 * @return void
+	 */
+	public function testStopImpersonatingNotImpersonating() {
+		$request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/']);
+		$request = $request->withAttribute('session', $this->sessionMock);
+		$response = new Response();
+
+		$authenticator = new SessionAuthenticator($this->identifiers);
+
+		$this->sessionMock->expects($this->once())
+			->method('check')
+			->with('AuthImpersonate')
+			->willReturn(false);
+
+		$this->sessionMock
+			->expects($this->never())
+			->method('read');
+
+		$this->sessionMock
+			->expects($this->never())
+			->method('delete');
+
+		$this->sessionMock
+			->expects($this->never())
+			->method('write');
+
+		$result = $authenticator->stopImpersonating($request, $response);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('request', $result);
+		$this->assertArrayHasKey('response', $result);
+		$this->assertInstanceOf(RequestInterface::class, $result['request']);
+		$this->assertInstanceOf(ResponseInterface::class, $result['response']);
+	}
+
+	/**
+	 * testIsImpersonating
+	 *
+	 * @return void
+	 */
+	public function testIsImpersonating() {
+		$request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/']);
+		$request = $request->withAttribute('session', $this->sessionMock);
+
+		$authenticator = new SessionAuthenticator($this->identifiers);
+
+		$this->sessionMock->expects($this->once())
+			->method('check')
+			->with('AuthImpersonate');
+
+		$result = $authenticator->isImpersonating($request);
+		$this->assertFalse($result);
+	}
+
+}

--- a/tests/test_app/Model/Table/UsersTable.php
+++ b/tests/test_app/Model/Table/UsersTable.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace TestApp\Model\Table;
+
+use Cake\ORM\Query\SelectQuery;
+use Cake\ORM\Table;
+
+class UsersTable extends Table {
+
+	/**
+	 * @param array $config
+	 * @return void
+	 */
+	public function initialize(array $config): void {
+		$this->belongsTo('DatabaseRoles', [
+			'foreignKey' => 'role_id',
+		]);
+	}
+
+	/**
+	 * @param \Cake\ORM\Query\SelectQuery $query
+	 * @return \Cake\ORM\Query\SelectQuery
+	 */
+	public function findActive(SelectQuery $query): SelectQuery {
+		return $query->contain(['DatabaseRoles']);
+	}
+
+}


### PR DESCRIPTION
This will only persist ID for the user(s) and always get up to date data from DB
Prevents also having to update the session after Account data edit, or prevent issues with another user (admin) modifying your data and having to force-update the session of this other user.
```php
  $service->loadAuthenticator('TinyAuth.Session', [
      'modelClass' => 'Users',
      'finder' => 'active',
  ]);
```