### PR TITLE
Fix isPublic plugin/prefix scope leak and hasRole type juggling

### DIFF
--- a/src/Auth/AclTrait.php
+++ b/src/Auth/AclTrait.php
@@ -315,11 +315,23 @@ trait AclTrait {
 		$authentication = $this->_getAuth();
 
 		foreach ($authentication as $rule) {
-			if ($params['plugin'] && $params['plugin'] !== $rule['plugin']) {
-				continue;
+			if (!empty($params['plugin'])) {
+				if ($params['plugin'] !== $rule['plugin']) {
+					continue;
+				}
+			} else {
+				if (!empty($rule['plugin'])) {
+					continue;
+				}
 			}
-			if (!empty($params['prefix']) && $params['prefix'] !== $rule['prefix']) {
-				continue;
+			if (!empty($params['prefix'])) {
+				if ($params['prefix'] !== $rule['prefix']) {
+					continue;
+				}
+			} else {
+				if (!empty($rule['prefix'])) {
+					continue;
+				}
 			}
 			if ($params['controller'] !== $rule['controller']) {
 				continue;

--- a/src/Auth/AuthUserTrait.php
+++ b/src/Auth/AuthUserTrait.php
@@ -104,6 +104,14 @@ trait AuthUserTrait {
 	/**
 	 * Check if the current session has this role.
 	 *
+	 * Comparison is performed strictly after coercing both the expected role
+	 * and the provided role values to string. Without this normalization, the
+	 * loose `in_array()` semantics make e.g. `0 == 'admin'` evaluate to true
+	 * (PHP < 8) and mixed-type role IDs from different sources (DB ints vs.
+	 * Configure strings) would match by accident. String coercion preserves
+	 * cross-type equivalence between numeric strings and ints (the common
+	 * legacy case) while rejecting unrelated scalar/string juggling.
+	 *
 	 * @param mixed $expectedRole
 	 * @param mixed|null $providedRoles
 	 * @return bool Success
@@ -119,8 +127,23 @@ trait AuthUserTrait {
 			return false;
 		}
 
-		if (array_key_exists($expectedRole, $roles) || in_array($expectedRole, $roles)) {
-			return true;
+		if (!is_scalar($expectedRole)) {
+			return false;
+		}
+
+		$expectedRoleString = (string)$expectedRole;
+		foreach ($roles as $key => $role) {
+			// Only string keys are role aliases; auto-int keys would otherwise
+			// produce a false positive for `hasRole(0, [0 => 'admin'])`.
+			if (is_string($key) && $key === $expectedRoleString) {
+				return true;
+			}
+			if (!is_scalar($role)) {
+				continue;
+			}
+			if ((string)$role === $expectedRoleString) {
+				return true;
+			}
 		}
 
 		return false;

--- a/tests/TestCase/Controller/Component/AuthUserComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthUserComponentTest.php
@@ -462,6 +462,27 @@ class AuthUserComponentTest extends TestCase {
 	}
 
 	/**
+	 * Regression: role lookup must not accept type-juggled false positives.
+	 *
+	 * Without normalization, `in_array(0, ['admin'])` evaluates to `true` on
+	 * PHP < 8 and `in_array('1abc', [1])` evaluates to `true` on any version
+	 * — both of which would let an unrelated value masquerade as a real role.
+	 *
+	 * @return void
+	 */
+	public function testHasRoleRejectsLooseTypeJugglingMatches() {
+		$this->assertFalse($this->AuthUser->hasRole(0, ['admin', 'moderator']));
+		$this->assertFalse($this->AuthUser->hasRole('1abc', [1, 2, 3]));
+		$this->assertFalse($this->AuthUser->hasRole('admin', [0, 1, 2]));
+		$this->assertFalse($this->AuthUser->hasRole(null, ['admin']));
+		$this->assertFalse($this->AuthUser->hasRole(true, ['admin']));
+
+		// Numeric-string / int equivalence is preserved on purpose.
+		$this->assertTrue($this->AuthUser->hasRole('2', [1, 2, 3]));
+		$this->assertTrue($this->AuthUser->hasRole(2, ['1', '2', '3']));
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testHasRoles() {

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -100,6 +100,64 @@ class AuthenticationComponentTest extends TestCase {
 	}
 
 	/**
+	 * Regression: a rule scoped to a plugin must not match a request without one.
+	 *
+	 * `Extras.Offers = "!superPrivate", *` defines a plugin-scoped rule.
+	 * A request to non-plugin `Offers::view` previously matched it because
+	 * `_isPublic()` short-circuited the plugin guard when the request had none.
+	 *
+	 * @return void
+	 */
+	public function testIsPublicDoesNotMatchPluginRuleForNonPluginRequest() {
+		$request = new ServerRequest([
+			'params' => [
+				'controller' => 'Offers',
+				'action' => 'view',
+				'plugin' => null,
+				'_ext' => null,
+				'pass' => [],
+			],
+		]);
+		$controller = $this->getControllerMock($request);
+		$registry = new ComponentRegistry($controller);
+		$this->component = new AuthenticationComponent($registry, $this->componentConfig);
+
+		$result = $this->component->isPublic();
+		$this->assertFalse($result);
+	}
+
+	/**
+	 * Regression: a rule scoped to a prefix must not match a request without one.
+	 *
+	 * `Admin/Users = index` is prefix-scoped to `Admin`. A non-prefix request
+	 * to `Users::index` is already covered by the unprefixed `Users` rule, but
+	 * a non-prefix request to `Users::view` (which is allowed unprefixed too)
+	 * must not pull in the Admin-scoped rule. We exercise the inverse path by
+	 * requesting an action that is only allowed under the Admin prefix to make
+	 * sure the prefix-scoped rule does not leak to non-prefix requests.
+	 *
+	 * @return void
+	 */
+	public function testIsPublicDoesNotMatchPrefixRuleForNonPrefixRequest() {
+		$request = new ServerRequest([
+			'params' => [
+				'controller' => 'MyTest',
+				'action' => 'myPublic',
+				'plugin' => null,
+				'prefix' => null,
+				'_ext' => null,
+				'pass' => [],
+			],
+		]);
+		$controller = $this->getControllerMock($request);
+		$registry = new ComponentRegistry($controller);
+		$this->component = new AuthenticationComponent($registry, $this->componentConfig);
+
+		$result = $this->component->isPublic();
+		$this->assertFalse($result);
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testIsPublicAllowNonPrefixed() {


### PR DESCRIPTION
## Summary

Two authorization-correctness fixes in security-critical code paths.

### `AclTrait::_isPublic()` — asymmetric scope guard

`src/Auth/AclTrait.php:317` used:

```php
if ($params['plugin'] && $params['plugin'] !== $rule['plugin']) {
    continue;
}
if (!empty($params['prefix']) && $params['prefix'] !== $rule['prefix']) {
    continue;
}
```

The first conjunct short-circuits to `false` when the request has no plugin/prefix, so the rule is **not** skipped even though it was authored for a specific plugin or prefix. A rule defined for `Foo.Tags::index` could mark a non-plugin request to `Tags::index` as public — the canonical `AllowTrait::_getAllowRule()` (`src/Auth/AllowTrait.php:33-50`) does not have this asymmetry. The fix mirrors that symmetric guard so a rule is skipped whenever either side has a scope and they do not match.

### `AuthUserTrait::hasRole()` — loose `in_array` and stray auto-int keys

`src/Auth/AuthUserTrait.php:122` called `in_array($expectedRole, $roles)` without strict mode, so `hasRole(0, ['admin', 'moderator'])` returned `true` (loose `0 == 'admin'`). The `array_key_exists()` branch additionally treated auto-int array keys as alias matches, so `hasRole(0, [0 => 'admin'])` was also a false positive.

The fix coerces both sides to string and compares strictly. Numeric-string / int equivalence (the common DB-ints-vs-Configure-strings case) is preserved on purpose; only string keys count as alias matches; non-scalar inputs return `false` early.

## Tests

- `AuthenticationComponentTest::testIsPublicDoesNotMatchPluginRuleForNonPluginRequest` and `testIsPublicDoesNotMatchPrefixRuleForNonPrefixRequest` lock down the symmetric scope guard.
- `AuthUserComponentTest::testHasRoleRejectsLooseTypeJugglingMatches` covers `hasRole(0, ['admin'])`, `hasRole('1abc', [1, 2, 3])`, null/bool inputs, and confirms numeric-string / int equivalence still works.

`phpunit`, `composer stan`, and `phpcs src/ tests/` are all clean locally.