### PR TITLE
Use plugin-specific i18n domain for translations

### DIFF
--- a/resources/locales/tinyauth.pot
+++ b/resources/locales/tinyauth.pot
@@ -1,0 +1,19 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2026-05-04 02:47+0200\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+msgid "You are not authorized to access that location."
+msgstr ""
+

--- a/src/Middleware/UnauthorizedHandler/ForbiddenCakeRedirectHandler.php
+++ b/src/Middleware/UnauthorizedHandler/ForbiddenCakeRedirectHandler.php
@@ -52,7 +52,7 @@ class ForbiddenCakeRedirectHandler extends CakeRedirectHandler {
 
 		$response = parent::handle($exception, $request, $options);
 
-		$message = $options['unauthorizedMessage'] ?? __('You are not authorized to access that location.');
+		$message = $options['unauthorizedMessage'] ?? __d('tinyauth', 'You are not authorized to access that location.');
 		if ($message) {
 			/** @var \Cake\Http\ServerRequest $request */
 			$request->getFlash()->error($message);

--- a/src/Middleware/UnauthorizedHandler/ForbiddenRedirectHandler.php
+++ b/src/Middleware/UnauthorizedHandler/ForbiddenRedirectHandler.php
@@ -49,7 +49,7 @@ class ForbiddenRedirectHandler extends RedirectHandler {
 
 		$response = parent::handle($exception, $request, $options);
 
-		$message = $options['unauthorizedMessage'] ?? __('You are not authorized to access that location.');
+		$message = $options['unauthorizedMessage'] ?? __d('tinyauth', 'You are not authorized to access that location.');
 		if ($message) {
 			/** @var \Cake\Http\ServerRequest $request */
 			$request->getFlash()->error($message);


### PR DESCRIPTION
## Summary

- Convert the 2 `__()` calls in the unauthorized-handler middleware to `__d('tinyauth', ...)` so plugin strings live in their own domain.
- Add `resources/locales/tinyauth.pot` (1 unique msgid — the unauthorized-access fallback message) generated via `bin/cake i18n extract` so language packs can be derived from a stable POT.

## Why

Plugin strings were landing in the host app's `default` domain. Anyone translating the host app would have ended up translating this plugin's UI under their own domain — and shipping a translated language pack with the plugin was effectively impossible.

## Verification (local)

- phpunit: 111 / 111 (2 pre-existing deprecations, 11 pre-existing notices — unrelated to this change)
- phpstan: no errors
- phpcs: clean