### PR TITLE
Allow authentication v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"cakephp/cakephp": "^5.1.1"
 	},
 	"require-dev": {
-		"cakephp/authentication": "^3.0.1",
+		"cakephp/authentication": "^3.0.1 || ^4.0",
 		"cakephp/authorization": "^3.0.1",
 		"cakephp/debug_kit": "^5.0.1",
 		"composer/semver": "^3.0",

--- a/src/Authenticator/PrimaryKeySessionAuthenticator.php
+++ b/src/Authenticator/PrimaryKeySessionAuthenticator.php
@@ -62,7 +62,7 @@ class PrimaryKeySessionAuthenticator extends AuthenticationSessionAuthenticator 
 			}
 		}
 
-		$user = $this->_identifier->identify([$this->getConfig('identifierKey') => $userId]);
+		$user = $this->getIdentifier()->identify([$this->getConfig('identifierKey') => $userId]);
 		if (!$user) {
 			return new Result(null, Result::FAILURE_IDENTITY_NOT_FOUND);
 		}

--- a/tests/TestCase/Authenticator/PrimaryKeySessionAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/PrimaryKeySessionAuthenticatorTest.php
@@ -5,7 +5,7 @@ namespace TinyAuth\Test\TestCase\Authenticator;
 
 use ArrayObject;
 use Authentication\Authenticator\Result;
-use Authentication\Identifier\IdentifierCollection;
+use Authentication\Identifier\IdentifierFactory;
 use Cake\Http\Exception\UnauthorizedException;
 use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
@@ -26,7 +26,7 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase {
 	];
 
 	/**
-	 * @var \Authentication\IdentifierCollection
+	 * @var \Authentication\Identifier\IdentifierInterface
 	 */
 	protected $identifiers;
 
@@ -41,9 +41,7 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->identifiers = new IdentifierCollection([
-			'Authentication.Password',
-		]);
+		$this->identifiers = IdentifierFactory::create('Authentication.Password');
 
 		$this->sessionMock = $this->getMockBuilder(Session::class)
 			->disableOriginalConstructor()
@@ -66,14 +64,13 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase {
 
 		$request = $request->withAttribute('session', $this->sessionMock);
 
-		$this->identifiers = new IdentifierCollection([
-			'Authentication.Token' => [
-				'tokenField' => 'id',
-				'dataField' => 'key',
-				'resolver' => [
-					'className' => 'Authentication.Orm',
-					'finder' => 'active',
-				],
+		$this->identifiers = IdentifierFactory::create([
+			'className' => 'Authentication.Token',
+			'tokenField' => 'id',
+			'dataField' => 'key',
+			'resolver' => [
+				'className' => 'Authentication.Orm',
+				'finder' => 'active',
 			],
 		]);
 
@@ -106,14 +103,13 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase {
 
 		$request = $request->withAttribute('session', $this->sessionMock);
 
-		$this->identifiers = new IdentifierCollection([
-			'Authentication.Token' => [
-				'tokenField' => 'id',
-				'dataField' => 'key',
-				'resolver' => [
-					'className' => 'Authentication.Orm',
-					'finder' => 'active',
-				],
+		$this->identifiers = IdentifierFactory::create([
+			'className' => 'Authentication.Token',
+			'tokenField' => 'id',
+			'dataField' => 'key',
+			'resolver' => [
+				'className' => 'Authentication.Orm',
+				'finder' => 'active',
 			],
 		]);
 

--- a/tests/TestCase/Authenticator/PrimaryKeySessionAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/PrimaryKeySessionAuthenticatorTest.php
@@ -29,7 +29,7 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase {
 	/**
 	 * @var \Authentication\Identifier\IdentifierInterface
 	 */
-	protected $identifiers;
+	protected $identifier;
 
 	/**
 	 * @var \Cake\Http\Session&\PHPUnit\Framework\MockObject\MockObject
@@ -42,7 +42,7 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->identifiers = new PasswordIdentifier();
+		$this->identifier = new PasswordIdentifier();
 
 		$this->sessionMock = $this->getMockBuilder(Session::class)
 			->disableOriginalConstructor()
@@ -65,7 +65,7 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase {
 
 		$request = $request->withAttribute('session', $this->sessionMock);
 
-		$this->identifiers = new TokenIdentifier([
+		$this->identifier = new TokenIdentifier([
 			'tokenField' => 'id',
 			'dataField' => 'key',
 			'resolver' => [
@@ -74,7 +74,7 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase {
 			],
 		]);
 
-		$authenticator = new PrimaryKeySessionAuthenticator($this->identifiers);
+		$authenticator = new PrimaryKeySessionAuthenticator($this->identifier);
 		$result = $authenticator->authenticate($request);
 
 		$this->assertInstanceOf(Result::class, $result);
@@ -103,7 +103,7 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase {
 
 		$request = $request->withAttribute('session', $this->sessionMock);
 
-		$this->identifiers = new TokenIdentifier([
+		$this->identifier = new TokenIdentifier([
 			'tokenField' => 'id',
 			'dataField' => 'key',
 			'resolver' => [
@@ -112,7 +112,7 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase {
 			],
 		]);
 
-		$authenticator = new PrimaryKeySessionAuthenticator($this->identifiers, []);
+		$authenticator = new PrimaryKeySessionAuthenticator($this->identifier, []);
 		$result = $authenticator->authenticate($request);
 
 		$this->assertInstanceOf(Result::class, $result);
@@ -137,7 +137,7 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase {
 
 		$request = $request->withAttribute('session', $this->sessionMock);
 
-		$authenticator = new PrimaryKeySessionAuthenticator($this->identifiers);
+		$authenticator = new PrimaryKeySessionAuthenticator($this->identifier);
 		$result = $authenticator->authenticate($request);
 
 		$this->assertInstanceOf(Result::class, $result);
@@ -159,7 +159,7 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase {
 
 		$request = $request->withAttribute('session', $this->sessionMock);
 
-		$authenticator = new PrimaryKeySessionAuthenticator($this->identifiers, []);
+		$authenticator = new PrimaryKeySessionAuthenticator($this->identifier, []);
 		$result = $authenticator->authenticate($request);
 
 		$this->assertInstanceOf(Result::class, $result);
@@ -175,7 +175,7 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase {
 		$request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/']);
 		$request = $request->withAttribute('session', $this->sessionMock);
 		$response = new Response();
-		$authenticator = new PrimaryKeySessionAuthenticator($this->identifiers);
+		$authenticator = new PrimaryKeySessionAuthenticator($this->identifier);
 
 		$data = new ArrayObject(['id' => 1]);
 
@@ -217,7 +217,7 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase {
 		$request = $request->withAttribute('session', $this->sessionMock);
 		$response = new Response();
 
-		$authenticator = new PrimaryKeySessionAuthenticator($this->identifiers);
+		$authenticator = new PrimaryKeySessionAuthenticator($this->identifier);
 
 		$this->sessionMock->expects($this->once())
 			->method('delete')
@@ -245,7 +245,7 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase {
 		$request = $request->withAttribute('session', $this->sessionMock);
 		$response = new Response();
 
-		$authenticator = new PrimaryKeySessionAuthenticator($this->identifiers);
+		$authenticator = new PrimaryKeySessionAuthenticator($this->identifier);
 		$usersTable = $this->fetchTable('Users');
 		$impersonator = $usersTable->newEntity([
 			'username' => 'mariano',
@@ -285,7 +285,7 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase {
 		$request = $request->withAttribute('session', $this->sessionMock);
 		$response = new Response();
 
-		$authenticator = new PrimaryKeySessionAuthenticator($this->identifiers);
+		$authenticator = new PrimaryKeySessionAuthenticator($this->identifier);
 		$impersonator = new ArrayObject([
 			'username' => 'mariano',
 			'password' => 'password',
@@ -318,7 +318,7 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase {
 		$request = $request->withAttribute('session', $this->sessionMock);
 		$response = new Response();
 
-		$authenticator = new PrimaryKeySessionAuthenticator($this->identifiers);
+		$authenticator = new PrimaryKeySessionAuthenticator($this->identifier);
 
 		$impersonator = new ArrayObject([
 			'username' => 'mariano',
@@ -364,7 +364,7 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase {
 		$request = $request->withAttribute('session', $this->sessionMock);
 		$response = new Response();
 
-		$authenticator = new PrimaryKeySessionAuthenticator($this->identifiers);
+		$authenticator = new PrimaryKeySessionAuthenticator($this->identifier);
 
 		$this->sessionMock->expects($this->once())
 			->method('check')
@@ -400,7 +400,7 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase {
 		$request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/']);
 		$request = $request->withAttribute('session', $this->sessionMock);
 
-		$authenticator = new PrimaryKeySessionAuthenticator($this->identifiers);
+		$authenticator = new PrimaryKeySessionAuthenticator($this->identifier);
 
 		$this->sessionMock->expects($this->once())
 			->method('check')

--- a/tests/TestCase/Authenticator/PrimaryKeySessionAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/PrimaryKeySessionAuthenticatorTest.php
@@ -5,8 +5,8 @@ namespace TinyAuth\Test\TestCase\Authenticator;
 
 use ArrayObject;
 use Authentication\Authenticator\Result;
-use Authentication\Identifier\IdentifierCollection;
-use Authentication\Identifier\IdentifierFactory;
+use Authentication\Identifier\PasswordIdentifier;
+use Authentication\Identifier\TokenIdentifier;
 use Cake\Http\Exception\UnauthorizedException;
 use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
@@ -42,7 +42,7 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->identifiers = $this->buildIdentifier('Authentication.Password');
+		$this->identifiers = new PasswordIdentifier();
 
 		$this->sessionMock = $this->getMockBuilder(Session::class)
 			->disableOriginalConstructor()
@@ -65,8 +65,7 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase {
 
 		$request = $request->withAttribute('session', $this->sessionMock);
 
-		$this->identifiers = $this->buildIdentifier([
-			'className' => 'Authentication.Token',
+		$this->identifiers = new TokenIdentifier([
 			'tokenField' => 'id',
 			'dataField' => 'key',
 			'resolver' => [
@@ -104,8 +103,7 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase {
 
 		$request = $request->withAttribute('session', $this->sessionMock);
 
-		$this->identifiers = $this->buildIdentifier([
-			'className' => 'Authentication.Token',
+		$this->identifiers = new TokenIdentifier([
 			'tokenField' => 'id',
 			'dataField' => 'key',
 			'resolver' => [
@@ -410,24 +408,6 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase {
 
 		$result = $authenticator->isImpersonating($request);
 		$this->assertFalse($result);
-	}
-
-	/**
-	 * @param array<string, mixed>|string $config
-	 * @return \Authentication\Identifier\IdentifierInterface
-	 */
-	protected function buildIdentifier(array|string $config) {
-		if (class_exists(IdentifierFactory::class)) {
-			return IdentifierFactory::create($config);
-		}
-
-		$identifierCollection = new IdentifierCollection(
-			is_string($config) ? [$config] : [$config['className'] => array_diff_key($config, ['className' => true])],
-		);
-
-		$className = is_string($config) ? $config : $config['className'];
-
-		return $identifierCollection->get($className);
 	}
 
 }

--- a/tests/TestCase/Authenticator/PrimaryKeySessionAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/PrimaryKeySessionAuthenticatorTest.php
@@ -5,6 +5,7 @@ namespace TinyAuth\Test\TestCase\Authenticator;
 
 use ArrayObject;
 use Authentication\Authenticator\Result;
+use Authentication\Identifier\IdentifierCollection;
 use Authentication\Identifier\IdentifierFactory;
 use Cake\Http\Exception\UnauthorizedException;
 use Cake\Http\Response;
@@ -41,7 +42,7 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->identifiers = IdentifierFactory::create('Authentication.Password');
+		$this->identifiers = $this->buildIdentifier('Authentication.Password');
 
 		$this->sessionMock = $this->getMockBuilder(Session::class)
 			->disableOriginalConstructor()
@@ -64,7 +65,7 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase {
 
 		$request = $request->withAttribute('session', $this->sessionMock);
 
-		$this->identifiers = IdentifierFactory::create([
+		$this->identifiers = $this->buildIdentifier([
 			'className' => 'Authentication.Token',
 			'tokenField' => 'id',
 			'dataField' => 'key',
@@ -103,7 +104,7 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase {
 
 		$request = $request->withAttribute('session', $this->sessionMock);
 
-		$this->identifiers = IdentifierFactory::create([
+		$this->identifiers = $this->buildIdentifier([
 			'className' => 'Authentication.Token',
 			'tokenField' => 'id',
 			'dataField' => 'key',
@@ -409,6 +410,24 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase {
 
 		$result = $authenticator->isImpersonating($request);
 		$this->assertFalse($result);
+	}
+
+	/**
+	 * @param array<string, mixed>|string $config
+	 * @return \Authentication\Identifier\IdentifierInterface
+	 */
+	protected function buildIdentifier(array|string $config) {
+		if (class_exists(IdentifierFactory::class)) {
+			return IdentifierFactory::create($config);
+		}
+
+		$identifierCollection = new IdentifierCollection(
+			is_string($config) ? [$config] : [$config['className'] => array_diff_key($config, ['className' => true])],
+		);
+
+		$className = is_string($config) ? $config : $config['className'];
+
+		return $identifierCollection->get($className);
 	}
 
 }


### PR DESCRIPTION
## Summary
- widen the  dev constraint to allow v4
- update the affected auth tests for the v4 identifier factory API
- keep the branch green against the new major
