### PR TITLE
Strict typing: Add native PHP 8.2 type declarations from the existing PHPDoc blocks

### DIFF
--- a/src/Auth/AclTrait.php
+++ b/src/Auth/AclTrait.php
@@ -4,6 +4,7 @@ namespace TinyAuth\Auth;
 
 use ArrayAccess;
 use BackedEnum;
+use Cake\Collection\CollectionInterface;
 use Cake\Core\Configure;
 use Cake\Core\Exception\CakeException;
 use Cake\Database\Type\EnumLabelInterface;
@@ -22,32 +23,32 @@ trait AclTrait {
 	/**
 	 * @var array|null
 	 */
-	protected $_acl;
+	protected ?array $_acl = null;
 
 	/**
 	 * @var array<int|string>|null
 	 */
-	protected $_roles;
+	protected ?array $_roles = null;
 
 	/**
 	 * @var array<string>|null
 	 */
-	protected $_prefixMap;
+	protected ?array $_prefixMap = null;
 
 	/**
 	 * @var array|null
 	 */
-	protected $_userRoles;
+	protected ?array $_userRoles = null;
 
 	/**
 	 * @var \TinyAuth\Auth\AclAdapter\AclAdapterInterface|null
 	 */
-	protected $_aclAdapter;
+	protected ?AclAdapterInterface $_aclAdapter = null;
 
 	/**
 	 * @var array|null
 	 */
-	protected $auth;
+	protected ?array $auth = null;
 
 	/**
 	 * Finds the authorization adapter to use for this request.
@@ -57,7 +58,7 @@ trait AclTrait {
 	 * @throws \InvalidArgumentException
 	 * @return \TinyAuth\Auth\AclAdapter\AclAdapterInterface
 	 */
-	protected function _loadAclAdapter($adapter) {
+	protected function _loadAclAdapter(string $adapter): AclAdapterInterface {
 		if ($this->_aclAdapter !== null) {
 			return $this->_aclAdapter;
 		}
@@ -134,7 +135,7 @@ trait AclTrait {
 	 *
 	 * @return bool
 	 */
-	protected function _isProtectedPrefix($prefix, array $protectedPrefixes) {
+	protected function _isProtectedPrefix($prefix, array $protectedPrefixes): bool {
 		foreach ($protectedPrefixes as $protectedPrefix) {
 			if ($prefix === $protectedPrefix || str_starts_with((string)$prefix, $protectedPrefix . '/')) {
 				return true;
@@ -157,7 +158,7 @@ trait AclTrait {
 	 * @param mixed $rule The value declared on the ACL rule.
 	 * @return bool True when both sides describe the same slot.
 	 */
-	protected function _matchesRouteSlot($request, $rule): bool {
+	protected function _matchesRouteSlot(mixed $request, mixed $rule): bool {
 		$requestEmpty = $request === null || $request === '';
 		$ruleEmpty = $rule === null || $rule === '';
 
@@ -177,7 +178,7 @@ trait AclTrait {
 	 *
 	 * @return bool
 	 */
-	protected function _check(array $userRoles, array $params) {
+	protected function _check(array $userRoles, array $params): bool {
 		// Allow access to all prefixed actions for users belonging to
 		// the specified role that matches the prefix.
 		$prefixMap = $this->getConfig('authorizeByPrefix');
@@ -269,7 +270,7 @@ trait AclTrait {
 	 *
 	 * @return array<string>
 	 */
-	protected function _prefixesFromRoles(array $roles) {
+	protected function _prefixesFromRoles(array $roles): array {
 		$names = array_keys($roles);
 		$prefixMap = [];
 		foreach ($names as $name) {
@@ -288,7 +289,7 @@ trait AclTrait {
 	 *
 	 * @return bool
 	 */
-	protected function _isAuthorizedByPrefix($prefix, array $prefixMap, array $userRoles, array $availableRoles) {
+	protected function _isAuthorizedByPrefix($prefix, array $prefixMap, array $userRoles, array $availableRoles): bool {
 		if (!$userRoles || !$prefixMap || !$availableRoles) {
 			return false;
 		}
@@ -315,7 +316,7 @@ trait AclTrait {
 	 *
 	 * @return array<string, mixed>
 	 */
-	protected function _normalizePrefixes(array $prefixes) {
+	protected function _normalizePrefixes(array $prefixes): array {
 		$normalized = [];
 		foreach ($prefixes as $prefix => $role) {
 			if (is_int($prefix)) {
@@ -334,7 +335,7 @@ trait AclTrait {
 	 *
 	 * @return bool
 	 */
-	protected function _isPublic(array $params) {
+	protected function _isPublic(array $params): bool {
 		$authentication = $this->_getAuth();
 
 		foreach ($authentication as $rule) {
@@ -376,7 +377,7 @@ trait AclTrait {
 	 * @throws \Cake\Core\Exception\CakeException
 	 * @return array
 	 */
-	protected function _getAuth() {
+	protected function _getAuth(): array {
 		if ($this->auth) {
 			return $this->auth;
 		}
@@ -399,7 +400,7 @@ trait AclTrait {
 	 * @param array|string|null $path
 	 * @return array
 	 */
-	protected function _getAcl($path = null) {
+	protected function _getAcl(array|string|null $path = null): array {
 		if ($this->getConfig('autoClearCache') && Configure::read('debug')) {
 			Cache::clear(Cache::KEY_ACL);
 		}
@@ -430,7 +431,7 @@ trait AclTrait {
 	 * @param string $file INI file name.
 	 * @return array List with all found files.
 	 */
-	protected function _parseFiles($paths, $file) {
+	protected function _parseFiles(array|string|null $paths, string $file): array {
 		return Utility::parseFiles($paths, $file);
 	}
 
@@ -440,7 +441,7 @@ trait AclTrait {
 	 * @param string $key INI section key as found in acl.ini
 	 * @return array<string, mixed> Array with named keys for controller, plugin and prefix
 	 */
-	protected function _deconstructIniKey($key) {
+	protected function _deconstructIniKey(string $key): array {
 		return Utility::deconstructIniKey($key);
 	}
 
@@ -450,7 +451,7 @@ trait AclTrait {
 	 * @param array $params The request params
 	 * @return string|null Hash with named keys for controller, plugin and prefix
 	 */
-	protected function _constructIniKey($params): ?string {
+	protected function _constructIniKey(array $params): ?string {
 		$res = $params['controller'] ?? null;
 		if ($res === null) {
 			return null;
@@ -474,7 +475,7 @@ trait AclTrait {
 	 * @throws \Cake\Core\Exception\CakeException
 	 * @return array<string, int|string> List with all available roles
 	 */
-	protected function _getAvailableRoles() {
+	protected function _getAvailableRoles(): array {
 		if ($this->_roles !== null) {
 			return $this->_roles;
 		}
@@ -526,7 +527,7 @@ trait AclTrait {
 		try {
 			$rolesTable = TableRegistry::getTableLocator()->get($rolesTableKey);
 			$roleIdColumn = $this->getConfig('roleIdColumn') ?: 'id';
-			$result = $rolesTable->find()->formatResults(function (ResultSetInterface $results) use ($roleIdColumn) {
+			$result = $rolesTable->find()->formatResults(function (ResultSetInterface $results) use ($roleIdColumn): CollectionInterface {
 				return $results->combine($this->getConfig('aliasColumn'), $roleIdColumn);
 			});
 		} catch (RuntimeException $e) {
@@ -548,7 +549,7 @@ trait AclTrait {
 	 * @param \ArrayAccess|array $user The user to get the roles for
 	 * @return array<string, int|string> List with all role ids belonging to the user
 	 */
-	protected function _getUserRoles(ArrayAccess|array $user) {
+	protected function _getUserRoles(ArrayAccess|array $user): array {
 		// Single-role from session
 		if (!$this->getConfig('multiRole')) {
 			$roleColumn = $this->getConfig('roleColumn');
@@ -611,7 +612,7 @@ trait AclTrait {
 	/**
 	 * @return string
 	 */
-	protected function _pivotTableName() {
+	protected function _pivotTableName(): string {
 		$pivotTableName = $this->getConfig('pivotTable');
 		if (!$pivotTableName) {
 			[, $rolesTableName] = pluginSplit($this->getConfig('rolesTable'));
@@ -632,7 +633,7 @@ trait AclTrait {
 	 * @param int $id User ID
 	 * @return array
 	 */
-	protected function _getRolesFromJunction($pivotTableName, $id) {
+	protected function _getRolesFromJunction(string $pivotTableName, $id): array {
 		if (isset($this->_userRoles[$id])) {
 			return $this->_userRoles[$id];
 		}
@@ -657,7 +658,7 @@ trait AclTrait {
 	 * @param array<int|string|\BackedEnum> $roles
 	 * @return array<string, int|string>
 	 */
-	protected function _mapped(array $roles) {
+	protected function _mapped(array $roles): array {
 		$availableRoles = $this->_getAvailableRoles();
 
 		$array = [];

--- a/src/Auth/AllowTrait.php
+++ b/src/Auth/AllowTrait.php
@@ -13,7 +13,7 @@ trait AllowTrait {
 	/**
 	 * @var \TinyAuth\Auth\AllowAdapter\AllowAdapterInterface|null
 	 */
-	protected $_allowAdapter;
+	protected ?AllowAdapterInterface $_allowAdapter = null;
 
 	/**
 	 * Get the rules for a specific controller.
@@ -24,7 +24,7 @@ trait AllowTrait {
 	 * @param array $params
 	 * @return array
 	 */
-	protected function _getAllowRule(array $params) {
+	protected function _getAllowRule(array $params): array {
 		$rules = $this->_getAllow($this->getConfig('allowFilePath'));
 
 		$allowDefaults = $this->_getAllowDefaultsForCurrentParams($params);
@@ -67,7 +67,7 @@ trait AllowTrait {
 	 * @param mixed $rule
 	 * @return bool
 	 */
-	protected function _matchesAllowSlot($request, $rule): bool {
+	protected function _matchesAllowSlot(mixed $request, mixed $rule): bool {
 		$requestEmpty = $request === null || $request === '';
 		$ruleEmpty = $rule === null || $rule === '';
 
@@ -83,11 +83,11 @@ trait AllowTrait {
 
 	/**
 	 * @param array $rule
-	 * @param string $action
+	 * @param string|null $action
 	 *
 	 * @return bool
 	 */
-	protected function _isActionAllowed(array $rule, $action) {
+	protected function _isActionAllowed(array $rule, ?string $action): bool {
 		$rule += [
 			'deny' => [],
 			'allow' => [],
@@ -104,7 +104,7 @@ trait AllowTrait {
 	 * @param array $params
 	 * @return array<string>
 	 */
-	protected function _getAllowDefaultsForCurrentParams(array $params) {
+	protected function _getAllowDefaultsForCurrentParams(array $params): array {
 		if ($this->getConfig('allowNonPrefixed') && empty($params['prefix'])) {
 			return ['*'];
 		}
@@ -132,7 +132,7 @@ trait AllowTrait {
 	 * @param string|null $path
 	 * @return array
 	 */
-	protected function _getAllow($path = null) {
+	protected function _getAllow(?string $path = null): array {
 		if ($this->getConfig('autoClearCache') && Configure::read('debug')) {
 			Cache::clear(Cache::KEY_ALLOW);
 		}
@@ -166,7 +166,7 @@ trait AllowTrait {
 	 * @throws \InvalidArgumentException
 	 * @return \TinyAuth\Auth\AllowAdapter\AllowAdapterInterface
 	 */
-	protected function _loadAllowAdapter($adapter) {
+	protected function _loadAllowAdapter(string $adapter): AllowAdapterInterface {
 		if ($this->_allowAdapter !== null) {
 			return $this->_allowAdapter;
 		}

--- a/src/Auth/AuthUserTrait.php
+++ b/src/Auth/AuthUserTrait.php
@@ -48,7 +48,7 @@ trait AuthUserTrait {
 	 *
 	 * @return string|int|null User id if existent, null otherwise.
 	 */
-	public function id() {
+	public function id(): string|int|null {
 		$field = $this->getConfig('idColumn');
 
 		return $this->user($field);
@@ -73,7 +73,7 @@ trait AuthUserTrait {
 	 * @param string|null $key Key in dot syntax.
 	 * @return mixed Data
 	 */
-	public function user(?string $key = null) {
+	public function user(?string $key = null): mixed {
 		$user = $this->_getUser();
 		if ($key === null) {
 			return $user;
@@ -114,7 +114,7 @@ trait AuthUserTrait {
 	 * @param mixed|null $providedRoles
 	 * @return bool Success
 	 */
-	public function hasRole($expectedRole, $providedRoles = null) {
+	public function hasRole(mixed $expectedRole, mixed $providedRoles = null): bool {
 		$roles = $providedRoles !== null ? (array)$providedRoles : $this->roles();
 
 		if (!$roles) {
@@ -154,7 +154,7 @@ trait AuthUserTrait {
 	 * @param mixed|null $providedRoles
 	 * @return bool Success
 	 */
-	public function hasRoles($expectedRoles, $oneRoleIsEnough = true, $providedRoles = null): bool {
+	public function hasRoles(mixed $expectedRoles, $oneRoleIsEnough = true, mixed $providedRoles = null): bool {
 		$roles = $providedRoles ?? $this->roles();
 
 		$expectedRoles = (array)$expectedRoles;

--- a/src/Auth/BaseAuthorize.php
+++ b/src/Auth/BaseAuthorize.php
@@ -30,17 +30,15 @@ abstract class BaseAuthorize {
 
 	/**
 	 * ComponentRegistry instance for getting more components.
-	 *
-	 * @var \Cake\Controller\ComponentRegistry
 	 */
-	protected $_registry;
+	protected ComponentRegistry $_registry;
 
 	/**
 	 * Default config for authorize objects.
 	 *
 	 * @var array<string, mixed>
 	 */
-	protected $_defaultConfig = [];
+	protected array $_defaultConfig = [];
 
 	/**
 	 * Constructor

--- a/src/Command/AddCommand.php
+++ b/src/Command/AddCommand.php
@@ -47,7 +47,7 @@ class AddCommand extends Command {
 	 * @param \Cake\Console\ConsoleIo $io The console io
 	 * @return int
 	 */
-	public function execute(Arguments $args, ConsoleIo $io) {
+	public function execute(Arguments $args, ConsoleIo $io): int {
 		$adder = $this->_getAdder();
 
 		$controller = $args->getArgument('controller');
@@ -77,7 +77,7 @@ class AddCommand extends Command {
 	/**
 	 * @return \TinyAuth\Sync\Adder
 	 */
-	protected function _getAdder() {
+	protected function _getAdder(): Adder {
 		return new Adder();
 	}
 
@@ -129,7 +129,7 @@ class AddCommand extends Command {
 	/**
 	 * @return array<string>
 	 */
-	protected function _getAvailableRoles() {
+	protected function _getAvailableRoles(): array {
 		$roles = (new TinyAuth())->getAvailableRoles();
 
 		return array_keys($roles);

--- a/src/Command/SyncCommand.php
+++ b/src/Command/SyncCommand.php
@@ -50,7 +50,7 @@ class SyncCommand extends Command {
 	 * @param \Cake\Console\ConsoleIo $io The console io
 	 * @return int
 	 */
-	public function execute(Arguments $args, ConsoleIo $io) {
+	public function execute(Arguments $args, ConsoleIo $io): int {
 		$syncer = $this->_getSyncer();
 		$syncer->syncAcl($args, $io);
 
@@ -64,7 +64,7 @@ class SyncCommand extends Command {
 	/**
 	 * @return \TinyAuth\Sync\Syncer
 	 */
-	protected function _getSyncer() {
+	protected function _getSyncer(): Syncer {
 		return new Syncer();
 	}
 
@@ -115,7 +115,7 @@ class SyncCommand extends Command {
 	/**
 	 * @return array<string>
 	 */
-	protected function _getAvailableRoles() {
+	protected function _getAvailableRoles(): array {
 		$roles = (new TinyAuth())->getAvailableRoles();
 
 		return array_keys($roles);

--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -52,7 +52,7 @@ class AuthenticationComponent extends CakeAuthenticationComponent {
 	 * @throws \Cake\Core\Exception\CakeException
 	 * @return bool
 	 */
-	public function isPublic(array $url = []) {
+	public function isPublic(array $url = []): bool {
 		if (!$url) {
 			$url = $this->getController()->getRequest()->getAttribute('params');
 		}
@@ -89,7 +89,7 @@ class AuthenticationComponent extends CakeAuthenticationComponent {
 	/**
 	 * @return void
 	 */
-	protected function _prepareAuthentication() {
+	protected function _prepareAuthentication(): void {
 		$params = $this->_registry->getController()->getRequest()->getAttribute('params');
 		if (!isset($params['plugin'])) {
 			$params['plugin'] = null;
@@ -128,7 +128,7 @@ class AuthenticationComponent extends CakeAuthenticationComponent {
 	/**
 	 * @return array
 	 */
-	protected function _getAllActions() {
+	protected function _getAllActions(): array {
 		$controller = $this->_registry->getController();
 
 		return get_class_methods($controller);

--- a/src/Controller/Component/AuthorizationComponent.php
+++ b/src/Controller/Component/AuthorizationComponent.php
@@ -24,7 +24,7 @@ class AuthorizationComponent extends CakeAuthorizationComponent {
 	/**
 	 * @var \TinyAuth\Controller\Component\AuthenticationComponent|null
 	 */
-	protected $_authentication;
+	protected ?AuthenticationComponent $_authentication = null;
 
 	/**
 	 * @param \Cake\Controller\ComponentRegistry $registry
@@ -77,7 +77,7 @@ class AuthorizationComponent extends CakeAuthorizationComponent {
 	 *
 	 * @return bool
 	 */
-	protected function _isUnauthenticatedAction() {
+	protected function _isUnauthenticatedAction(): bool {
 		if ($this->_authentication === null) {
 			return false;
 		}

--- a/src/Panel/AuthPanel.php
+++ b/src/Panel/AuthPanel.php
@@ -40,7 +40,7 @@ class AuthPanel extends DebugPanel {
 	/**
 	 * @var bool|null
 	 */
-	protected $isPublic;
+	protected ?bool $isPublic = null;
 
 	/**
 	 * @var array
@@ -147,7 +147,7 @@ class AuthPanel extends DebugPanel {
 	 *
 	 * @return array
 	 */
-	protected function _injectRole(array $user, $role, $id) {
+	protected function _injectRole(array $user, $role, string|int $id): array {
 		if (!$this->getConfig('multiRole')) {
 			$user[$this->getConfig('roleColumn')] = $id;
 
@@ -178,7 +178,7 @@ class AuthPanel extends DebugPanel {
 	 *
 	 * @return array
 	 */
-	protected function _generateUser($role, $id): array {
+	protected function _generateUser($role, string|int $id): array {
 		$user = [
 			'id' => 0,
 		];
@@ -198,7 +198,7 @@ class AuthPanel extends DebugPanel {
 	 *
 	 * @return array
 	 */
-	protected function _getParams(array $params) {
+	protected function _getParams(array $params): array {
 		$params += [
 			'prefix' => null,
 			'plugin' => null,
@@ -213,9 +213,9 @@ class AuthPanel extends DebugPanel {
 	/**
 	 * @param array $params
 	 *
-	 * @return string
+	 * @return string|null
 	 */
-	protected function _getPath(array $params) {
+	protected function _getPath(array $params): ?string {
 		$path = $params['controller'];
 		if ($params['prefix']) {
 			$path = $params['prefix'] . '/' . $path;

--- a/src/Sync/Adder.php
+++ b/src/Sync/Adder.php
@@ -35,7 +35,7 @@ class Adder {
 	/**
 	 * @var array|null
 	 */
-	protected $authAllow;
+	protected ?array $authAllow = null;
 
 	/**
 	 * Adds or updates a controller/action entry in the ACL INI file.
@@ -59,7 +59,7 @@ class Adder {
 	 *
 	 * @return void
 	 */
-	public function addAcl(string $controller, string $action, array $roles, Arguments $args, ConsoleIo $io) {
+	public function addAcl(string $controller, string $action, array $roles, Arguments $args, ConsoleIo $io): void {
 		$path = $this->config['aclFilePath'] ?: ROOT . DS . 'config' . DS;
 		$file = $path . $this->config['aclFile'];
 		$content = Utility::parseFile($file);
@@ -94,7 +94,7 @@ class Adder {
 	 * @param string|null $plugin
 	 * @return array
 	 */
-	protected function _getControllers($plugin) {
+	protected function _getControllers(?string $plugin): array {
 		if ($plugin === 'all') {
 			$plugins = Plugin::loaded();
 
@@ -123,7 +123,7 @@ class Adder {
 	 *
 	 * @return array
 	 */
-	protected function _parseControllers($folder, $plugin, $prefix = null) {
+	protected function _parseControllers(string $folder, ?string $plugin, ?string $prefix = null): array {
 		$folderContent = $this->_listDirectory($folder);
 
 		$controllers = [];
@@ -202,7 +202,7 @@ class Adder {
 	 * @param string|null $prefix
 	 * @return bool
 	 */
-	protected function _noAuthenticationNeeded($name, $plugin, $prefix) {
+	protected function _noAuthenticationNeeded(string $name, ?string $plugin, ?string $prefix): bool {
 		if ($this->authAllow === null) {
 			$this->authAllow = $this->_parseAuthAllow();
 		}
@@ -219,7 +219,7 @@ class Adder {
 	/**
 	 * @return array
 	 */
-	protected function _parseAuthAllow() {
+	protected function _parseAuthAllow(): array {
 		$defaults = [
 			'allowFilePath' => null,
 			'allowFile' => 'auth_allow.ini',

--- a/src/Sync/Syncer.php
+++ b/src/Sync/Syncer.php
@@ -14,7 +14,7 @@ class Syncer {
 	/**
 	 * @var array|null
 	 */
-	protected $authAllow;
+	protected ?array $authAllow = null;
 
 	/**
 	 * Synchronizes all discovered controllers with the ACL INI file.
@@ -39,7 +39,7 @@ class Syncer {
 	 * @param \Cake\Console\ConsoleIo $io Console I/O for output
 	 * @return void
 	 */
-	public function syncAcl(Arguments $args, ConsoleIo $io) {
+	public function syncAcl(Arguments $args, ConsoleIo $io): void {
 		$defaults = [
 			'aclFile' => 'auth_acl.ini',
 			'aclFilePath' => null,
@@ -84,7 +84,7 @@ class Syncer {
 	 * @param string|null $plugin
 	 * @return array
 	 */
-	protected function _getControllers($plugin) {
+	protected function _getControllers(?string $plugin): array {
 		if ($plugin === 'all') {
 			$plugins = Plugin::loaded();
 
@@ -113,7 +113,7 @@ class Syncer {
 	 *
 	 * @return array
 	 */
-	protected function _parseControllers($folder, $plugin, $prefix = null) {
+	protected function _parseControllers(string $folder, ?string $plugin, ?string $prefix = null): array {
 		$folderContent = $this->_listDirectory($folder);
 
 		$controllers = [];
@@ -194,7 +194,7 @@ class Syncer {
 	 * @param string|null $prefix
 	 * @return bool
 	 */
-	protected function _noAuthenticationNeeded($name, $plugin, $prefix) {
+	protected function _noAuthenticationNeeded(string $name, ?string $plugin, ?string $prefix): bool {
 		if ($this->authAllow === null) {
 			$this->authAllow = $this->_parseAuthAllow();
 		}
@@ -211,7 +211,7 @@ class Syncer {
 	/**
 	 * @return array
 	 */
-	protected function _parseAuthAllow() {
+	protected function _parseAuthAllow(): array {
 		$defaults = [
 			'allowFilePath' => null,
 			'allowFile' => 'auth_allow.ini',

--- a/src/Utility/Config.php
+++ b/src/Utility/Config.php
@@ -14,12 +14,12 @@ class Config {
 	 *
 	 * @var array
 	 */
-	protected static $_config = [];
+	protected static array $_config = [];
 
 	/**
 	 * @var array
 	 */
-	protected static $_defaultConfig = [
+	protected static array $_defaultConfig = [
 		// allow
 		'allowAdapter' => IniAllowAdapter::class,
 		'allowFilePath' => null, // Possible to locate INI file at given path e.g. Plugin::configPath('Admin'), filePath is also available for shared config
@@ -52,7 +52,7 @@ class Config {
 	/**
 	 * @return array
 	 */
-	public static function all() {
+	public static function all(): array {
 		if (!static::$_config) {
 			$config = (array)Configure::read('TinyAuth') + static::$_defaultConfig;
 
@@ -71,7 +71,7 @@ class Config {
 	 * @throws \Cake\Core\Exception\CakeException
 	 * @return mixed
 	 */
-	public static function get($key) {
+	public static function get(string $key): mixed {
 		$config = static::all();
 		if (!isset($config[$key])) {
 			throw new CakeException('Key ' . $key . ' not found in config.');
@@ -83,7 +83,7 @@ class Config {
 	/**
 	 * @return void
 	 */
-	public static function drop() {
+	public static function drop(): void {
 		static::$_config = [];
 	}
 

--- a/src/Utility/TinyAuth.php
+++ b/src/Utility/TinyAuth.php
@@ -29,7 +29,7 @@ class TinyAuth {
 	/**
 	 * @return array<string, int|string>
 	 */
-	public function getAvailableRoles() {
+	public function getAvailableRoles(): array {
 		return $this->_getAvailableRoles();
 	}
 

--- a/src/Utility/Utility.php
+++ b/src/Utility/Utility.php
@@ -13,7 +13,7 @@ class Utility {
 	 * @param string $key INI section key as found in authentication.ini
 	 * @return array<string, mixed> Array with named keys for controller, plugin and prefix
 	 */
-	public static function deconstructIniKey($key) {
+	public static function deconstructIniKey(string $key): array {
 		$res = [
 			'plugin' => null,
 			'prefix' => null,
@@ -40,7 +40,7 @@ class Utility {
 	 * @param string $file INI file name.
 	 * @return array List with all found files.
 	 */
-	public static function parseFiles($paths, $file) {
+	public static function parseFiles(array|string|null $paths, string $file): array {
 		if ($paths === null) {
 			$paths = ROOT . DS . 'config' . DS;
 		}
@@ -60,7 +60,7 @@ class Utility {
 	 * @throws \Cake\Core\Exception\CakeException
 	 * @return array List
 	 */
-	public static function parseFile($ini) {
+	public static function parseFile(string $ini): array {
 		if (!file_exists($ini)) {
 			throw new CakeException(sprintf('Missing TinyAuth config file (%s)', $ini));
 		}
@@ -88,7 +88,7 @@ class Utility {
 	 *
 	 * @return bool
 	 */
-	public static function generateFile($file, array $content) {
+	public static function generateFile(string $file, array $content): bool {
 		$string = static::buildIniString($content);
 
 		return (bool)file_put_contents($file, $string);
@@ -99,7 +99,7 @@ class Utility {
 	 *
 	 * @return string
 	 */
-	public static function buildIniString(array $a) {
+	public static function buildIniString(array $a): string {
 		$out = [];
 		foreach ($a as $rootkey => $rootvalue) {
 			$out[] = "[$rootkey]";

--- a/src/View/Helper/AuthUserHelper.php
+++ b/src/View/Helper/AuthUserHelper.php
@@ -62,7 +62,7 @@ class AuthUserHelper extends Helper {
 	 * @throws \Cake\Core\Exception\CakeException
 	 * @return bool
 	 */
-	public function hasAccess(array $url) {
+	public function hasAccess(array $url): bool {
 		if (isset($url['_name'])) {
 			//throw MissingRouteException if necessary
 			Router::url($url);
@@ -107,7 +107,7 @@ class AuthUserHelper extends Helper {
 	 * @param array<string, mixed> $options
 	 * @return string
 	 */
-	public function link($title, array $url, array $options = []) {
+	public function link(string $title, array $url, array $options = []) {
 		if (!$this->hasAccess($url)) {
 			return $this->_default($title, $options);
 		}
@@ -127,7 +127,7 @@ class AuthUserHelper extends Helper {
 	 * @param array<string, mixed> $options
 	 * @return string
 	 */
-	public function postLink($title, array $url, array $options = []) {
+	public function postLink(string $title, array $url, array $options = []) {
 		if (!$this->hasAccess($url)) {
 			return $this->_default($title, $options);
 		}
@@ -141,7 +141,7 @@ class AuthUserHelper extends Helper {
 	 * @param array<string, mixed> $options
 	 * @return string
 	 */
-	protected function _default($title, array $options) {
+	protected function _default(string $title, array $options) {
 		$options += [
 			'default' => '',
 			'escape' => true,

--- a/src/View/Helper/AuthenticationHelper.php
+++ b/src/View/Helper/AuthenticationHelper.php
@@ -38,7 +38,7 @@ class AuthenticationHelper extends Helper {
 	 * @param array $url
 	 * @return bool
 	 */
-	public function isPublic(array $url = []) {
+	public function isPublic(array $url = []): bool {
 		if (!$url) {
 			$url = $this->_View->getRequest()->getAttribute('params');
 		}

--- a/tests/test_app/Auth/TestTinyAuthorize.php
+++ b/tests/test_app/Auth/TestTinyAuthorize.php
@@ -24,11 +24,11 @@ class TestTinyAuthorize extends TinyAuthorize {
 	}
 
 	/**
-	 * @param string|null $path
+	 * @param array<string>|string|null $path
 	 *
 	 * @return array
 	 */
-	protected function _getAcl($path = null) {
+	protected function _getAcl(array|string|null $path = null): array {
 		$path = Plugin::path('TinyAuth') . 'tests' . DS . 'test_files' . DS;
 
 		return parent::_getAcl($path);

--- a/tests/test_app/Controller/Component/TestAuthUserComponent.php
+++ b/tests/test_app/Controller/Component/TestAuthUserComponent.php
@@ -16,11 +16,11 @@ class TestAuthUserComponent extends AuthUserComponent {
 	}
 
 	/**
-	 * @param string|null $path
+	 * @param array<string>|string|null $path
 	 *
 	 * @return array
 	 */
-	protected function _getAcl($path = null) {
+	protected function _getAcl(array|string|null $path = null): array {
 		$path = Plugin::path('TinyAuth') . 'tests' . DS . 'test_files' . DS;
 
 		return parent::_getAcl($path);


### PR DESCRIPTION
# Strict typing: Add native PHP 8.2 type declarations from the existing PHPDoc blocks

## Preamble
I've been running TinyAuth on a project and noticed most signatures still keep their types in the PHPDoc blocks only. Based on latest effort across CakePHP packages and core, I guess going to improve and leverage PHP's native type system is a welcome change. 😄 

## What was changed ? 
Applies native parameter, return and property type declarations throughout the plugin, derived from the existing `@param` / `@return` / `@var` PHPDoc and confirmed against actual usage.

## Left untyped on purpose
A few signatures stay loose, because tightening them would change behaviour. If you take a look into the changes you would see why. 

## PHP Version matching composer + README 
Targets the package's PHP 8.2 minimum. PHPDoc is kept where it carries generics or array (basic) shapes (e.g. `array<string, int|string>`) that native types (based on PHP 8.2) cannot express.

## How it was done
First pass with Rector (type-declaration set pinned to 8.2), the rest by hand.
phpstan level 8 and cs pass, test suite unchanged. Happy to adjust.

And thanks for your great work @dereuromark !