### PR TITLE
Fix wildcard-public controllers redirecting unknown actions to login (#173)

### DIFF
--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -111,6 +111,14 @@ class AuthenticationComponent extends CakeAuthenticationComponent {
 		$allowed = $this->unauthenticatedActions;
 		if (in_array('*', $rule['allow'], true)) {
 			$allowed = $this->_getAllActions();
+			// A wildcard rule makes the whole controller public, including actions
+			// that do not exist as methods. Keep the current action allowed so an
+			// unknown action falls through to MissingActionException (404) instead
+			// of being treated as protected and redirected to login.
+			// @see https://github.com/dereuromark/cakephp-tinyauth/issues/173
+			if (isset($params['action'])) {
+				$allowed[] = $params['action'];
+			}
 		} elseif (!empty($rule['allow'])) {
 			$allowed = array_merge($allowed, $rule['allow']);
 		}

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -7,6 +7,7 @@ use Cake\Controller\Controller;
 use Cake\Core\Plugin;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
+use ReflectionMethod;
 use TinyAuth\Controller\Component\AuthenticationComponent;
 
 class AuthenticationComponentTest extends TestCase {
@@ -228,6 +229,67 @@ class AuthenticationComponentTest extends TestCase {
 
 		$result = $this->component->isPublic();
 		$this->assertFalse($result);
+	}
+
+	/**
+	 * A wildcard (`*`) allow rule must keep unauthenticated access open even for
+	 * actions that do not exist on the controller. Otherwise an unknown action
+	 * under a fully public controller is treated as protected and unauthenticated
+	 * users get redirected to login instead of receiving the MissingActionException
+	 * (404) that the action's absence should produce.
+	 *
+	 * @see https://github.com/dereuromark/cakephp-tinyauth/issues/173
+	 *
+	 * @return void
+	 */
+	public function testPrepareAuthenticationWildcardAllowsUnknownAction() {
+		$request = new ServerRequest([
+			'params' => [
+				'controller' => 'Offers',
+				'action' => 'thisDoesNotExist',
+				'plugin' => 'Extras',
+				'prefix' => null,
+				'_ext' => null,
+				'pass' => [],
+			],
+		]);
+		$controller = $this->getControllerMock($request);
+		$registry = new ComponentRegistry($controller);
+		$this->component = new AuthenticationComponent($registry, $this->componentConfig);
+
+		$method = new ReflectionMethod($this->component, '_prepareAuthentication');
+		$method->setAccessible(true);
+		$method->invoke($this->component);
+
+		$this->assertContains('thisDoesNotExist', $this->component->getUnauthenticatedActions());
+	}
+
+	/**
+	 * A wildcard allow rule with an explicit deny must still protect the denied
+	 * action, even though the requested action does not exist on the controller.
+	 *
+	 * @return void
+	 */
+	public function testPrepareAuthenticationWildcardStillHonorsDeny() {
+		$request = new ServerRequest([
+			'params' => [
+				'controller' => 'Offers',
+				'action' => 'superPrivate',
+				'plugin' => 'Extras',
+				'prefix' => null,
+				'_ext' => null,
+				'pass' => [],
+			],
+		]);
+		$controller = $this->getControllerMock($request);
+		$registry = new ComponentRegistry($controller);
+		$this->component = new AuthenticationComponent($registry, $this->componentConfig);
+
+		$method = new ReflectionMethod($this->component, '_prepareAuthentication');
+		$method->setAccessible(true);
+		$method->invoke($this->component);
+
+		$this->assertNotContains('superPrivate', $this->component->getUnauthenticatedActions());
 	}
 
 	/**


### PR DESCRIPTION
Fixes the regression reported in #173: after switching from the legacy `AuthComponent` to the new `AuthenticationComponent`, hitting an **undefined** action on a fully public controller (`Pages = *`) redirected unauthenticated users to login instead of returning a 404.

## Cause

A `*` allow rule is expanded to the controller's concrete method list via `get_class_methods()` so it can be passed to the cakephp/authentication plugin (which has no wildcard support). An action that does not exist as a method is not in that list, so it was dropped from the unauthenticated set. Unauthenticated users then failed the identity check and got redirected to login, never reaching the dispatcher where the missing action would raise `MissingActionException` (404).

The legacy `AuthComponent` checked the allow rule directly (honoring `*` for any action string), so the request dispatched and produced the 404.

## Fix

Under a wildcard allow, keep the current request action in the unauthenticated set even when it is not a real method. Unknown actions then fall through to `MissingActionException` (404), matching the old behavior. Explicit denies (`!superPrivate`) still take precedence.

This also repairs the Acl path: `AuthorizationComponent::_isUnauthenticatedAction()` consumes the same `getUnauthenticatedActions()` list, so the single fix covers both authentication and authorization skip logic.

## Tests

Added two regression tests in `AuthenticationComponentTest`:
- wildcard allow keeps an unknown action unauthenticated
- wildcard allow still honors an explicit deny for a missing action
