### PR TITLE
Keep wildcard-public controllers public for unknown actions (3.x)

### DIFF
--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -93,7 +93,8 @@ class AuthenticationComponent extends CakeAuthenticationComponent {
 	 * @return void
 	 */
 	protected function _prepareAuthentication() {
-		$rule = $this->_getAllowRule($this->_registry->getController()->getRequest()->getAttribute('params'));
+		$params = $this->_registry->getController()->getRequest()->getAttribute('params');
+		$rule = $this->_getAllowRule($params);
 		if (!$rule) {
 			return;
 		}
@@ -105,6 +106,14 @@ class AuthenticationComponent extends CakeAuthenticationComponent {
 		$allowed = $this->unauthenticatedActions;
 		if (in_array('*', $rule['allow'], true)) {
 			$allowed = $this->_getAllActions();
+			// A wildcard rule makes the whole controller public, including actions
+			// that do not exist as methods. Keep the current action allowed so an
+			// unknown action falls through to MissingActionException (404) instead
+			// of being treated as protected and redirected to login.
+			// @see https://github.com/dereuromark/cakephp-tinyauth/issues/173
+			if (isset($params['action'])) {
+				$allowed[] = $params['action'];
+			}
 		} elseif (!empty($rule['allow'])) {
 			$allowed = array_merge($allowed, $rule['allow']);
 		}

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -8,6 +8,7 @@ use Cake\Core\Plugin;
 use Cake\Event\Event;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
+use ReflectionMethod;
 use TinyAuth\Controller\Component\AuthenticationComponent;
 
 class AuthenticationComponentTest extends TestCase {
@@ -158,6 +159,63 @@ class AuthenticationComponentTest extends TestCase {
 
 		$result = $this->component->isPublic();
 		$this->assertFalse($result);
+	}
+
+	/**
+	 * A wildcard (`*`) allow rule must keep unauthenticated access open even for
+	 * actions that do not exist on the controller. Otherwise an unknown action
+	 * under a fully public controller is treated as protected and unauthenticated
+	 * users get redirected to login instead of receiving the MissingActionException
+	 * (404) that the action's absence should produce.
+	 *
+	 * @see https://github.com/dereuromark/cakephp-tinyauth/issues/173
+	 *
+	 * @return void
+	 */
+	public function testPrepareAuthenticationWildcardAllowsUnknownAction() {
+		$request = new ServerRequest(['params' => [
+			'controller' => 'Offers',
+			'action' => 'thisDoesNotExist',
+			'plugin' => 'Extras',
+			'prefix' => null,
+			'_ext' => null,
+			'pass' => [],
+		]]);
+		$controller = $this->getControllerMock($request);
+		$registry = new ComponentRegistry($controller);
+		$this->component = new AuthenticationComponent($registry, $this->componentConfig);
+
+		$method = new ReflectionMethod($this->component, '_prepareAuthentication');
+		$method->setAccessible(true);
+		$method->invoke($this->component);
+
+		$this->assertContains('thisDoesNotExist', $this->component->getUnauthenticatedActions());
+	}
+
+	/**
+	 * A wildcard allow rule with an explicit deny must still protect the denied
+	 * action, even though the requested action does not exist on the controller.
+	 *
+	 * @return void
+	 */
+	public function testPrepareAuthenticationWildcardStillHonorsDeny() {
+		$request = new ServerRequest(['params' => [
+			'controller' => 'Offers',
+			'action' => 'superPrivate',
+			'plugin' => 'Extras',
+			'prefix' => null,
+			'_ext' => null,
+			'pass' => [],
+		]]);
+		$controller = $this->getControllerMock($request);
+		$registry = new ComponentRegistry($controller);
+		$this->component = new AuthenticationComponent($registry, $this->componentConfig);
+
+		$method = new ReflectionMethod($this->component, '_prepareAuthentication');
+		$method->setAccessible(true);
+		$method->invoke($this->component);
+
+		$this->assertNotContains('superPrivate', $this->component->getUnauthenticatedActions());
 	}
 
 	/**


### PR DESCRIPTION
Backport of #174 to the `cake3` (3.x) branch.

A `*` allow rule is expanded to the controller's concrete method list via `get_class_methods()` so it can be handed to the cakephp/authentication plugin, which has no wildcard support. An action that does not exist as a method was therefore dropped from the unauthenticated set, so unauthenticated users hit the identity check and got redirected to login instead of receiving the `MissingActionException` (404) the missing action should produce.

Now the current request action is kept in the unauthenticated set under a wildcard allow, so unknown actions fall through to `MissingActionException`, matching the old `AuthComponent` behavior. Explicit denies still take precedence.

Fixes #173 for 3.x (confirmed by the reporter against the 5.x fix).
