### PR TITLE
Fix isPublic plugin/prefix scope leak and hasRole type juggling (3.x)

### DIFF
--- a/src/Auth/AclTrait.php
+++ b/src/Auth/AclTrait.php
@@ -265,11 +265,23 @@ trait AclTrait {
 		$authentication = $this->_getAuth();
 
 		foreach ($authentication as $rule) {
-			if ($params['plugin'] && $params['plugin'] !== $rule['plugin']) {
-				continue;
+			if (!empty($params['plugin'])) {
+				if ($params['plugin'] !== $rule['plugin']) {
+					continue;
+				}
+			} else {
+				if (!empty($rule['plugin'])) {
+					continue;
+				}
 			}
-			if (!empty($params['prefix']) && $params['prefix'] !== $rule['prefix']) {
-				continue;
+			if (!empty($params['prefix'])) {
+				if ($params['prefix'] !== $rule['prefix']) {
+					continue;
+				}
+			} else {
+				if (!empty($rule['prefix'])) {
+					continue;
+				}
 			}
 			if ($params['controller'] !== $rule['controller']) {
 				continue;

--- a/src/Auth/AllowTrait.php
+++ b/src/Auth/AllowTrait.php
@@ -30,11 +30,23 @@ trait AllowTrait {
 		$allowDefaults = $this->_getAllowDefaultsForCurrentParams($params);
 
 		foreach ($rules as $rule) {
-			if ($params['plugin'] && $params['plugin'] !== $rule['plugin']) {
-				continue;
+			if (!empty($params['plugin'])) {
+				if ($params['plugin'] !== $rule['plugin']) {
+					continue;
+				}
+			} else {
+				if (!empty($rule['plugin'])) {
+					continue;
+				}
 			}
-			if (!empty($params['prefix']) && $params['prefix'] !== $rule['prefix']) {
-				continue;
+			if (!empty($params['prefix'])) {
+				if ($params['prefix'] !== $rule['prefix']) {
+					continue;
+				}
+			} else {
+				if (!empty($rule['prefix'])) {
+					continue;
+				}
 			}
 			if ($params['controller'] !== $rule['controller']) {
 				continue;

--- a/src/Auth/AuthUserTrait.php
+++ b/src/Auth/AuthUserTrait.php
@@ -98,6 +98,14 @@ trait AuthUserTrait {
 	/**
 	 * Check if the current session has this role.
 	 *
+	 * Comparison is performed strictly after coercing both the expected role
+	 * and the provided role values to string. Without this normalization, the
+	 * loose `in_array()` semantics make e.g. `0 == 'admin'` evaluate to true
+	 * (PHP < 8) and mixed-type role IDs from different sources (DB ints vs.
+	 * Configure strings) would match by accident. String coercion preserves
+	 * cross-type equivalence between numeric strings and ints (the common
+	 * legacy case) while rejecting unrelated scalar/string juggling.
+	 *
 	 * @param mixed $expectedRole
 	 * @param mixed|null $providedRoles
 	 * @return bool Success
@@ -113,9 +121,25 @@ trait AuthUserTrait {
 			return false;
 		}
 
-		if (array_key_exists($expectedRole, $roles) || in_array($expectedRole, $roles)) {
-			return true;
+		if (!is_scalar($expectedRole)) {
+			return false;
 		}
+
+		$expectedRoleString = (string)$expectedRole;
+		foreach ($roles as $key => $role) {
+			// Only string keys are role aliases; auto-int keys would otherwise
+			// produce a false positive for `hasRole(0, [0 => 'admin'])`.
+			if (is_string($key) && $key === $expectedRoleString) {
+				return true;
+			}
+			if (!is_scalar($role)) {
+				continue;
+			}
+			if ((string)$role === $expectedRoleString) {
+				return true;
+			}
+		}
+
 		return false;
 	}
 

--- a/tests/TestCase/Controller/Component/AuthUserComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthUserComponentTest.php
@@ -265,6 +265,27 @@ class AuthUserComponentTest extends TestCase {
 	}
 
 	/**
+	 * Regression: role lookup must not accept type-juggled false positives.
+	 *
+	 * Without normalization, `in_array(0, ['admin'])` evaluates to `true` on
+	 * PHP < 8 and `in_array('1abc', [1])` evaluates to `true` on any version
+	 * — both of which would let an unrelated value masquerade as a real role.
+	 *
+	 * @return void
+	 */
+	public function testHasRoleRejectsLooseTypeJugglingMatches() {
+		$this->assertFalse($this->AuthUser->hasRole(0, ['admin', 'moderator']));
+		$this->assertFalse($this->AuthUser->hasRole('1abc', [1, 2, 3]));
+		$this->assertFalse($this->AuthUser->hasRole('admin', [0, 1, 2]));
+		$this->assertFalse($this->AuthUser->hasRole(null, ['admin']));
+		$this->assertFalse($this->AuthUser->hasRole(true, ['admin']));
+
+		// Numeric-string / int equivalence is preserved on purpose.
+		$this->assertTrue($this->AuthUser->hasRole('2', [1, 2, 3]));
+		$this->assertTrue($this->AuthUser->hasRole(2, ['1', '2', '3']));
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testHasRoles() {

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -161,6 +161,56 @@ class AuthenticationComponentTest extends TestCase {
 	}
 
 	/**
+	 * Regression: a rule scoped to a plugin must not match a request without one.
+	 *
+	 * `Extras.Offers = "!superPrivate", *` defines a plugin-scoped rule.
+	 * A request to non-plugin `Offers::view` previously matched it because
+	 * `_isPublic()` short-circuited the plugin guard when the request had none.
+	 *
+	 * @return void
+	 */
+	public function testIsPublicDoesNotMatchPluginRuleForNonPluginRequest() {
+		$request = new ServerRequest(['params' => [
+			'controller' => 'Offers',
+			'action' => 'view',
+			'plugin' => null,
+			'_ext' => null,
+			'pass' => [],
+		]]);
+		$controller = $this->getControllerMock($request);
+		$registry = new ComponentRegistry($controller);
+		$this->component = new AuthenticationComponent($registry, $this->componentConfig);
+
+		$result = $this->component->isPublic();
+		$this->assertFalse($result);
+	}
+
+	/**
+	 * Regression: a rule scoped to a prefix must not match a request without one.
+	 *
+	 * `admin/my_prefix/MyTest = myPublic` is prefix-scoped. A non-prefix request
+	 * to `MyTest::myPublic` must not pull in the prefix-scoped rule.
+	 *
+	 * @return void
+	 */
+	public function testIsPublicDoesNotMatchPrefixRuleForNonPrefixRequest() {
+		$request = new ServerRequest(['params' => [
+			'controller' => 'MyTest',
+			'action' => 'myPublic',
+			'plugin' => null,
+			'prefix' => null,
+			'_ext' => null,
+			'pass' => [],
+		]]);
+		$controller = $this->getControllerMock($request);
+		$registry = new ComponentRegistry($controller);
+		$this->component = new AuthenticationComponent($registry, $this->componentConfig);
+
+		$result = $this->component->isPublic();
+		$this->assertFalse($result);
+	}
+
+	/**
 	 * @param \Cake\Http\ServerRequest $request
 	 * @return \Cake\Controller\Controller|\PHPUnit_Framework_MockObject_MockObject
 	 */


### PR DESCRIPTION
Backport of #165 to the `cake3` (3.x) branch.

**isPublic plugin/prefix scope leak**
The plugin/prefix guards used asymmetric checks that short-circuited to "no scope mismatch" when the request itself had no plugin or prefix. A plugin-scoped (`Extras.Offers = *`) or prefix-scoped (`admin/my_prefix/MyTest = myPublic`) allow rule therefore leaked into a request that had no plugin/prefix. The guards are now symmetric: a rule is skipped whenever either side carries a scope and the two do not match.

On this branch `isPublic()` resolves rules through `AllowTrait::_getAllowRule()`, so the symmetric guard lives there; `AclTrait::_isPublic()` is mirrored for the authorization path.

**hasRole type juggling**
`AuthUserTrait::hasRole()` used a loose `in_array()` that matched `0` against any non-numeric string and treated auto-int array keys as alias matches. Both sides are now coerced to string and compared strictly, while numeric-string vs int equivalence (the common legacy case) is preserved and only string array keys count as aliases. Non-scalar inputs are rejected early.

Regression tests added for both paths.
