### PR TITLE
Fix wildcard unknown-action redirect, isPublic scope leak and hasRole juggling (3.x)

### DIFF
--- a/src/Auth/AclTrait.php
+++ b/src/Auth/AclTrait.php
@@ -312,11 +312,23 @@ trait AclTrait {
 		$authentication = $this->_getAuth();
 
 		foreach ($authentication as $rule) {
-			if ($params['plugin'] && $params['plugin'] !== $rule['plugin']) {
-				continue;
+			if (!empty($params['plugin'])) {
+				if ($params['plugin'] !== $rule['plugin']) {
+					continue;
+				}
+			} else {
+				if (!empty($rule['plugin'])) {
+					continue;
+				}
 			}
-			if (!empty($params['prefix']) && $params['prefix'] !== $rule['prefix']) {
-				continue;
+			if (!empty($params['prefix'])) {
+				if ($params['prefix'] !== $rule['prefix']) {
+					continue;
+				}
+			} else {
+				if (!empty($rule['prefix'])) {
+					continue;
+				}
 			}
 			if ($params['controller'] !== $rule['controller']) {
 				continue;

--- a/src/Auth/AuthUserTrait.php
+++ b/src/Auth/AuthUserTrait.php
@@ -100,6 +100,14 @@ trait AuthUserTrait {
 	/**
 	 * Check if the current session has this role.
 	 *
+	 * Comparison is performed strictly after coercing both the expected role
+	 * and the provided role values to string. Without this normalization, the
+	 * loose `in_array()` semantics make e.g. `0 == 'admin'` evaluate to true
+	 * (PHP < 8) and mixed-type role IDs from different sources (DB ints vs.
+	 * Configure strings) would match by accident. String coercion preserves
+	 * cross-type equivalence between numeric strings and ints (the common
+	 * legacy case) while rejecting unrelated scalar/string juggling.
+	 *
 	 * @param mixed $expectedRole
 	 * @param mixed|null $providedRoles
 	 * @return bool Success
@@ -115,8 +123,23 @@ trait AuthUserTrait {
 			return false;
 		}
 
-		if (array_key_exists($expectedRole, $roles) || in_array($expectedRole, $roles)) {
-			return true;
+		if (!is_scalar($expectedRole)) {
+			return false;
+		}
+
+		$expectedRoleString = (string)$expectedRole;
+		foreach ($roles as $key => $role) {
+			// Only string keys are role aliases; auto-int keys would otherwise
+			// produce a false positive for `hasRole(0, [0 => 'admin'])`.
+			if (is_string($key) && $key === $expectedRoleString) {
+				return true;
+			}
+			if (!is_scalar($role)) {
+				continue;
+			}
+			if ((string)$role === $expectedRoleString) {
+				return true;
+			}
 		}
 
 		return false;

--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -116,6 +116,14 @@ class AuthenticationComponent extends CakeAuthenticationComponent {
 		$allowed = $this->unauthenticatedActions;
 		if (in_array('*', $rule['allow'], true)) {
 			$allowed = $this->_getAllActions();
+			// A wildcard rule makes the whole controller public, including actions
+			// that do not exist as methods. Keep the current action allowed so an
+			// unknown action falls through to MissingActionException (404) instead
+			// of being treated as protected and redirected to login.
+			// @see https://github.com/dereuromark/cakephp-tinyauth/issues/173
+			if (isset($params['action'])) {
+				$allowed[] = $params['action'];
+			}
 		} elseif (!empty($rule['allow'])) {
 			$allowed = array_merge($allowed, $rule['allow']);
 		}

--- a/tests/TestCase/Controller/Component/AuthUserComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthUserComponentTest.php
@@ -262,6 +262,27 @@ class AuthUserComponentTest extends TestCase {
 	}
 
 	/**
+	 * Regression: role lookup must not accept type-juggled false positives.
+	 *
+	 * Without normalization, `in_array(0, ['admin'])` evaluates to `true` on
+	 * PHP < 8 and `in_array('1abc', [1])` evaluates to `true` on any version
+	 * — both of which would let an unrelated value masquerade as a real role.
+	 *
+	 * @return void
+	 */
+	public function testHasRoleRejectsLooseTypeJugglingMatches() {
+		$this->assertFalse($this->AuthUser->hasRole(0, ['admin', 'moderator']));
+		$this->assertFalse($this->AuthUser->hasRole('1abc', [1, 2, 3]));
+		$this->assertFalse($this->AuthUser->hasRole('admin', [0, 1, 2]));
+		$this->assertFalse($this->AuthUser->hasRole(null, ['admin']));
+		$this->assertFalse($this->AuthUser->hasRole(true, ['admin']));
+
+		// Numeric-string / int equivalence is preserved on purpose.
+		$this->assertTrue($this->AuthUser->hasRole('2', [1, 2, 3]));
+		$this->assertTrue($this->AuthUser->hasRole(2, ['1', '2', '3']));
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testHasRoles() {

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -8,6 +8,7 @@ use Cake\Core\Plugin;
 use Cake\Event\Event;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
+use ReflectionMethod;
 use TinyAuth\Controller\Component\AuthenticationComponent;
 
 class AuthenticationComponentTest extends TestCase {
@@ -163,6 +164,117 @@ class AuthenticationComponentTest extends TestCase {
 		$controller = $this->getControllerMock($request);
 		$registry = new ComponentRegistry($controller);
 		$this->component = new AuthenticationComponent($registry, ['allowPrefixes' => 'FooBar'] + $this->componentConfig);
+
+		$result = $this->component->isPublic();
+		$this->assertFalse($result);
+	}
+
+	/**
+	 * A wildcard (`*`) allow rule must keep unauthenticated access open even for
+	 * actions that do not exist on the controller. Otherwise an unknown action
+	 * under a fully public controller is treated as protected and unauthenticated
+	 * users get redirected to login instead of receiving the MissingActionException
+	 * (404) that the action's absence should produce.
+	 *
+	 * @see https://github.com/dereuromark/cakephp-tinyauth/issues/173
+	 *
+	 * @return void
+	 */
+	public function testPrepareAuthenticationWildcardAllowsUnknownAction() {
+		$request = new ServerRequest([
+		'params' => [
+			'controller' => 'Offers',
+			'action' => 'thisDoesNotExist',
+			'plugin' => 'Extras',
+			'prefix' => null,
+			'_ext' => null,
+			'pass' => [],
+		]]);
+		$controller = $this->getControllerMock($request);
+		$registry = new ComponentRegistry($controller);
+		$this->component = new AuthenticationComponent($registry, $this->componentConfig);
+
+		$method = new ReflectionMethod($this->component, '_prepareAuthentication');
+		$method->setAccessible(true);
+		$method->invoke($this->component);
+
+		$this->assertContains('thisDoesNotExist', $this->component->getUnauthenticatedActions());
+	}
+
+	/**
+	 * A wildcard allow rule with an explicit deny must still protect the denied
+	 * action, even though the requested action does not exist on the controller.
+	 *
+	 * @return void
+	 */
+	public function testPrepareAuthenticationWildcardStillHonorsDeny() {
+		$request = new ServerRequest([
+		'params' => [
+			'controller' => 'Offers',
+			'action' => 'superPrivate',
+			'plugin' => 'Extras',
+			'prefix' => null,
+			'_ext' => null,
+			'pass' => [],
+		]]);
+		$controller = $this->getControllerMock($request);
+		$registry = new ComponentRegistry($controller);
+		$this->component = new AuthenticationComponent($registry, $this->componentConfig);
+
+		$method = new ReflectionMethod($this->component, '_prepareAuthentication');
+		$method->setAccessible(true);
+		$method->invoke($this->component);
+
+		$this->assertNotContains('superPrivate', $this->component->getUnauthenticatedActions());
+	}
+
+	/**
+	 * Regression: a rule scoped to a plugin must not match a request without one.
+	 *
+	 * `Extras.Offers = "!superPrivate", *` defines a plugin-scoped rule.
+	 * A request to non-plugin `Offers::view` previously matched it because
+	 * `_isPublic()` short-circuited the plugin guard when the request had none.
+	 *
+	 * @return void
+	 */
+	public function testIsPublicDoesNotMatchPluginRuleForNonPluginRequest() {
+		$request = new ServerRequest([
+		'params' => [
+			'controller' => 'Offers',
+			'action' => 'view',
+			'plugin' => null,
+			'_ext' => null,
+			'pass' => [],
+		]]);
+		$controller = $this->getControllerMock($request);
+		$registry = new ComponentRegistry($controller);
+		$this->component = new AuthenticationComponent($registry, $this->componentConfig);
+
+		$result = $this->component->isPublic();
+		$this->assertFalse($result);
+	}
+
+	/**
+	 * Regression: a rule scoped to a prefix must not match a request without one.
+	 *
+	 * `Admin/MyPrefix/MyTest = myPublic` is prefix-scoped. A non-prefix request
+	 * to `MyTest::myPublic` must not pull in the prefix-scoped rule.
+	 *
+	 * @return void
+	 */
+	public function testIsPublicDoesNotMatchPrefixRuleForNonPrefixRequest() {
+		$request = new ServerRequest([
+		'params' => [
+			'controller' => 'MyTest',
+			'action' => 'myPublic',
+			'plugin' => null,
+			'prefix' => null,
+			'_ext' => null,
+			'pass' => [],
+		]]);
+		$controller = $this->getControllerMock($request);
+		$registry = new ComponentRegistry($controller);
+		$this->component = new AuthenticationComponent($registry, $this->componentConfig);
 
 		$result = $this->component->isPublic();
 		$this->assertFalse($result);


### PR DESCRIPTION
## Problem

The `3.2.1` release was meant to ship the missing-action wildcard fix (and the isPublic/hasRole fixes) to the CakePHP 4 line, but it was tagged on the `cake3` branch (CakePHP 3, `cakephp/cakephp ^3.7`) instead of `cake4`. Every other `3.x` tag lives on `cake4` (CakePHP 4), so `3.2.1` is an anomaly: a CakePHP 4 app cannot even install it. The fixes therefore never reached the `3.x` line that users of `3.2.0` actually run.

Reported in issue 173.

## What this does

Ports the fixes onto `cake4` so the `3.x` line reaches parity with the master (`5.x`) release:

- **Wildcard unknown action**: under a `*` allow rule, an action that does not exist as a controller method is kept in the unauthenticated set, so an unknown action falls through to `MissingActionException` (404) for guests instead of a login redirect. Explicit denies still win.
- **isPublic scope leak**: `AclTrait::_isPublic()` plugin/prefix guards are now symmetric, so a plugin- or prefix-scoped rule no longer matches a request without one. (`AllowTrait` already carried the symmetric guard on this branch.)
- **hasRole type juggling**: `AuthUserTrait::hasRole()` compares strictly after string coercion, preserving numeric-string/int equivalence while rejecting `0 == 'admin'`-style false positives and auto-int alias keys.

Regression tests added for all three paths.

## Gates

phpunit (103 tests), phpstan, phpcs all green locally.
