### PR TITLE
Fix PHPStan on CakePHP 5.4

### DIFF
--- a/src/View/Helper/AuthUserHelper.php
+++ b/src/View/Helper/AuthUserHelper.php
@@ -24,7 +24,7 @@ class AuthUserHelper extends Helper {
 	use	AuthUserTrait;
 
 	/**
-	 * @var array
+	 * @var array<int|string, array<string, mixed>|string>
 	 */
 	protected array $helpers = ['Html', 'Form'];
 

--- a/src/View/Helper/AuthenticationHelper.php
+++ b/src/View/Helper/AuthenticationHelper.php
@@ -16,7 +16,7 @@ class AuthenticationHelper extends Helper {
 	use AllowTrait;
 
 	/**
-	 * @var array
+	 * @var array<int|string, array<string, mixed>|string>
 	 */
 	protected array $helpers = [];
 


### PR DESCRIPTION
Updates helper/component annotations for CakePHP 5.4/PHPStan covariance checks.\n\nVerified locally with CakePHP 5.4.0-RC2:\n- composer stan\n- composer cs-check\n- composer test